### PR TITLE
feat: eventyay field discovery scaffold

### DIFF
--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -1,0 +1,71 @@
+from django.utils.translation import gettext_lazy as _
+
+QUESTION_TYPE_MAP = {
+    "N": "number",
+    "B": "yes/no",
+    "D": "date",
+    "W": "date",
+    "H": "date",
+    "M": "text",
+    "C": "text",
+    # "F" intentionally omitted — file uploads are not syncable
+}
+
+
+def get_available_fields(object_type: str, event=None) -> list[dict]:
+    """
+    Returns a list of available fields for a given object type ('order' or 'order_position').
+    Includes standard fields, invoice address fields (for order), and active event questions (for order_position).
+    """
+    if object_type == "order":
+        return [
+            {"key": "code", "label": _("Order code"), "data_type": "text"},
+            {"key": "status", "label": _("Order status"), "data_type": "text"},
+            {"key": "total", "label": _("Order total"), "data_type": "number"},
+            {"key": "datetime", "label": _("Order datetime"), "data_type": "date"},
+            {"key": "email", "label": _("Order email"), "data_type": "text"},
+            {"key": "invoice_name", "label": _("Invoice name"), "data_type": "text"},
+            {
+                "key": "invoice_company",
+                "label": _("Invoice company"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_address",
+                "label": _("Invoice address"),
+                "data_type": "text",
+            },
+        ]
+    elif object_type == "order_position":
+        if event is None:
+            raise ValueError("event is required when object_type is 'order_position'")
+
+        fields = [
+            {"key": "attendee_name", "label": _("Attendee name"), "data_type": "text"},
+            {
+                "key": "attendee_email",
+                "label": _("Attendee email"),
+                "data_type": "text",
+            },
+        ]
+
+        questions = event.questions.filter(active=True)
+        for q in questions:
+            if q.type == "F":
+                continue
+
+            data_type = QUESTION_TYPE_MAP.get(q.type, "text")
+
+            fields.append(
+                {
+                    "key": f"question_{q.identifier}",
+                    "label": str(q.question),
+                    "data_type": data_type,
+                }
+            )
+
+        return fields
+
+    raise ValueError(
+        f"Unknown object_type: {object_type!r}. Expected 'order' or 'order_position'."
+    )

--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -27,91 +27,175 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
     if object_type == "order":
         return [
             # Standard order fields
-            {"key": "code", "label": _("Order code"), "data_type": "text"},
-            {"key": "status", "label": _("Order status"), "data_type": "text"},
-            {"key": "total", "label": _("Order total"), "data_type": "number"},
-            {"key": "datetime", "label": _("Order date and time"), "data_type": "date"},
-            {"key": "email", "label": _("Order email"), "data_type": "text"},
+            {
+                "key": "code",
+                "label": _("Order code"),
+                "data_type": "text",
+                "category": "Order details",
+            },
+            {
+                "key": "status",
+                "label": _("Order status"),
+                "data_type": "text",
+                "category": "Order details",
+            },
+            {
+                "key": "total",
+                "label": _("Order total"),
+                "data_type": "number",
+                "category": "Order details",
+            },
+            {
+                "key": "datetime",
+                "label": _("Order date and time"),
+                "data_type": "date",
+                "category": "Order details",
+            },
+            {
+                "key": "email",
+                "label": _("Order email"),
+                "data_type": "text",
+                "category": "Order details",
+            },
             {
                 "key": "email_domain",
                 "label": _("Order email domain"),
                 "data_type": "text",
+                "category": "Order details",
             },
             {
                 "key": "event_and_order_code",
                 "label": _("Event and order code"),
                 "data_type": "text",
+                "category": "Order details",
             },
             {
                 "key": "payment_datetime",
                 "label": _("Payment date and time"),
                 "data_type": "date",
+                "category": "Order details",
             },
-            {"key": "locale", "label": _("Order locale"), "data_type": "text"},
-            {"key": "order_link", "label": _("Order link"), "data_type": "text"},
+            {
+                "key": "locale",
+                "label": _("Order locale"),
+                "data_type": "text",
+                "category": "Order details",
+            },
+            {
+                "key": "order_link",
+                "label": _("Order link"),
+                "data_type": "text",
+                "category": "Order details",
+            },
+            {
+                "key": "phone",
+                "label": _("Order phone"),
+                "data_type": "text",
+                "category": "Order details",
+            },
+            {
+                "key": "comment",
+                "label": _("Order comment"),
+                "data_type": "text",
+                "category": "Order details",
+            },
+            {
+                "key": "testmode",
+                "label": _("Is test mode"),
+                "data_type": "yes/no",
+                "category": "Order details",
+            },
             # Invoice fields
             {
                 "key": "invoice_name",
                 "label": _("Invoice address name"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_company",
                 "label": _("Invoice address company"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_given_name",
                 "label": _("Invoice given name"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_family_name",
                 "label": _("Invoice family name"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_street",
                 "label": _("Invoice street"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
-            {"key": "invoice_zip", "label": _("Invoice zip code"), "data_type": "text"},
-            {"key": "invoice_city", "label": _("Invoice city"), "data_type": "text"},
+            {
+                "key": "invoice_zip",
+                "label": _("Invoice zip code"),
+                "data_type": "text",
+                "category": "Invoice details",
+            },
+            {
+                "key": "invoice_city",
+                "label": _("Invoice city"),
+                "data_type": "text",
+                "category": "Invoice details",
+            },
             {
                 "key": "invoice_country",
                 "label": _("Invoice country"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_state",
                 "label": _("Invoice state"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_vat_id",
                 "label": _("Invoice VAT ID"),
                 "data_type": "text",
+                "category": "Invoice details",
             },
             {
                 "key": "invoice_is_business",
                 "label": _("Invoice is business"),
                 "data_type": "yes/no",
+                "category": "Invoice details",
             },
-            {"key": "phone", "label": _("Order phone"), "data_type": "text"},
-            {"key": "comment", "label": _("Order comment"), "data_type": "text"},
-            {"key": "testmode", "label": _("Is test mode"), "data_type": "yes/no"},
             # Event information
-            {"key": "event_slug", "label": _("Event short form"), "data_type": "text"},
-            {"key": "event_name", "label": _("Event name"), "data_type": "text"},
+            {
+                "key": "event_slug",
+                "label": _("Event short form"),
+                "data_type": "text",
+                "category": "Event information",
+            },
+            {
+                "key": "event_name",
+                "label": _("Event name"),
+                "data_type": "text",
+                "category": "Event information",
+            },
             {
                 "key": "event_start_date",
                 "label": _("Event start date"),
                 "data_type": "date",
+                "category": "Event information",
             },
             {
                 "key": "event_end_date",
                 "label": _("Event end date"),
                 "data_type": "date",
+                "category": "Event information",
             },
         ]
     elif object_type == "order_position":
@@ -124,174 +208,208 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                 "key": "attendee_name",
                 "label": _("Attendee name"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.attendee_name
             {
                 "key": "attendee_given_name",
                 "label": _("Attendee given name"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.attendee_name_parts.get('given_name')
             {
                 "key": "attendee_family_name",
                 "label": _("Attendee family name"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.attendee_name_parts.get('family_name')
             {
                 "key": "attendee_email",
                 "label": _("Attendee email"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.attendee_email
             {
                 "key": "company",
                 "label": _("Company"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.company
             {
                 "key": "job_title",
                 "label": _("Job title"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.job_title
             {
                 "key": "street",
                 "label": _("Street"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.street
             {
                 "key": "zipcode",
                 "label": _("Zipcode"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.zipcode
             {
                 "key": "city",
                 "label": _("City"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.city
             {
                 "key": "country",
                 "label": _("Country"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: str(position.country) if position.country else None
             {
                 "key": "state",
                 "label": _("State"),
                 "data_type": "text",
+                "category": "Attendee details",
             },  # Extract via: position.state
             {
                 "key": "voucher",
                 "label": _("Voucher code"),
                 "data_type": "text",
+                "category": "Ticket details",
             },  # Extract via: position.voucher.code if position.voucher else None
             {
                 "key": "price",
                 "label": _("Ticket price"),
                 "data_type": "number",
+                "category": "Ticket details",
             },  # Extract via: position.price
             {
                 "key": "positionid",
                 "label": _("Position ID"),
                 "data_type": "number",
+                "category": "Ticket details",
             },  # Extract via: position.positionid
             {
                 "key": "secret",
                 "label": _("Ticket secret"),
                 "data_type": "text",
+                "category": "Ticket details",
             },  # Extract via: position.secret
             # Fields via item/product relationship
             {
                 "key": "item_name",
                 "label": _("Product name"),
                 "data_type": "text",
+                "category": "Ticket details",
             },  # Extract via: position.item.name
             {
                 "key": "item_admission",
                 "label": _("Is admission"),
                 "data_type": "yes/no",
+                "category": "Ticket details",
             },  # Extract via: position.item.admission
             # Fields via order relationship
             {
                 "key": "order_code",
                 "label": _("Order code"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.code
             {
                 "key": "order_email",
                 "label": _("Order email"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.email
             {
                 "key": "order_email_domain",
                 "label": _("Order email domain"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.email.split('@')[-1] if position.order.email else None
             {
                 "key": "order_total",
                 "label": _("Order total"),
                 "data_type": "number",
+                "category": "Order details",
             },  # Extract via: position.order.total
             {
                 "key": "order_status",
                 "label": _("Order status"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.status
             {
                 "key": "order_datetime",
                 "label": _("Order datetime"),
                 "data_type": "date",
+                "category": "Order details",
             },  # Extract via: position.order.datetime
             {
                 "key": "order_locale",
                 "label": _("Order locale"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.locale
             {
                 "key": "order_phone",
                 "label": _("Order phone"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.phone
             {
                 "key": "order_comment",
                 "label": _("Order comment"),
                 "data_type": "text",
+                "category": "Order details",
             },  # Extract via: position.order.comment
             # Invoice fields via order relationship
             {
                 "key": "invoice_name",
                 "label": _("Invoice address name"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.name
             {
                 "key": "invoice_company",
                 "label": _("Invoice address company"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.company
             {
                 "key": "invoice_street",
                 "label": _("Invoice street"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.street
             {
                 "key": "invoice_zip",
                 "label": _("Invoice zip code"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.zipcode
             {
                 "key": "invoice_city",
                 "label": _("Invoice city"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.city
             {
                 "key": "invoice_country",
                 "label": _("Invoice country"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.country
             {
                 "key": "invoice_state",
                 "label": _("Invoice state"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.state
             {
                 "key": "invoice_vat_id",
                 "label": _("Invoice VAT ID"),
                 "data_type": "text",
+                "category": "Invoice details",
             },  # Extract via: position.order.invoice_address.vat_id
         ]
 
@@ -307,6 +425,7 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                     "key": f"question_{q.identifier}",
                     "label": str(q.question),
                     "data_type": data_type,
+                    "category": "Questions",
                 }
             )
 

--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -1,14 +1,21 @@
 from django.utils.translation import gettext_lazy as _
+from eventyay.base.models import Question
 
 QUESTION_TYPE_MAP = {
-    "N": "number",
-    "B": "yes/no",
-    "D": "date",
-    "W": "date",
-    "H": "date",
-    "M": "text",
-    "C": "text",
-    # "F" intentionally omitted — file uploads are not syncable
+    Question.TYPE_NUMBER: "number",
+    Question.TYPE_BOOLEAN: "yes/no",
+    Question.TYPE_DATE: "date",
+    Question.TYPE_DATETIME: "date",
+    Question.TYPE_TIME: "date",
+    Question.TYPE_CHOICE_MULTIPLE: "text",
+    Question.TYPE_CHOICE: "text",
+    Question.TYPE_STRING: "text",
+    Question.TYPE_TEXT: "text",
+    Question.TYPE_CHOICE_DROPDOWN: "text",
+    Question.TYPE_COUNTRYCODE: "text",
+    Question.TYPE_PHONENUMBER: "text",
+    Question.TYPE_DESCRIPTION: "text",
+    # Question.TYPE_FILE intentionally omitted — file uploads are not syncable
 }
 
 
@@ -216,7 +223,7 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
 
         questions = event.questions.filter(active=True)
         for q in questions:
-            if q.type == "F":
+            if q.type == Question.TYPE_FILE:
                 continue
 
             data_type = QUESTION_TYPE_MAP.get(q.type, "text")

--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -19,21 +19,74 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
     """
     if object_type == "order":
         return [
+            # Standard order fields
             {"key": "code", "label": _("Order code"), "data_type": "text"},
             {"key": "status", "label": _("Order status"), "data_type": "text"},
             {"key": "total", "label": _("Order total"), "data_type": "number"},
-            {"key": "datetime", "label": _("Order datetime"), "data_type": "date"},
+            {"key": "datetime", "label": _("Order date and time"), "data_type": "date"},
             {"key": "email", "label": _("Order email"), "data_type": "text"},
-            {"key": "invoice_name", "label": _("Invoice name"), "data_type": "text"},
             {
-                "key": "invoice_company",
-                "label": _("Invoice company"),
+                "key": "email_domain",
+                "label": _("Order email domain"),
                 "data_type": "text",
             },
             {
-                "key": "invoice_address",
-                "label": _("Invoice address"),
+                "key": "event_and_order_code",
+                "label": _("Event and order code"),
                 "data_type": "text",
+            },
+            {
+                "key": "payment_datetime",
+                "label": _("Payment date and time"),
+                "data_type": "date",
+            },
+            {"key": "locale", "label": _("Order locale"), "data_type": "text"},
+            {"key": "order_link", "label": _("Order link"), "data_type": "text"},
+            # Invoice fields
+            {
+                "key": "invoice_name",
+                "label": _("Invoice address name"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_company",
+                "label": _("Invoice address company"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_given_name",
+                "label": _("Invoice given name"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_family_name",
+                "label": _("Invoice family name"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_street",
+                "label": _("Invoice street"),
+                "data_type": "text",
+            },
+            {"key": "invoice_zip", "label": _("Invoice zip code"), "data_type": "text"},
+            {"key": "invoice_city", "label": _("Invoice city"), "data_type": "text"},
+            {
+                "key": "invoice_country",
+                "label": _("Invoice country"),
+                "data_type": "text",
+            },
+            # Event information
+            {"key": "event_slug", "label": _("Event short form"), "data_type": "text"},
+            {"key": "event_name", "label": _("Event name"), "data_type": "text"},
+            {
+                "key": "event_start_date",
+                "label": _("Event start date"),
+                "data_type": "date",
+            },
+            {
+                "key": "event_end_date",
+                "label": _("Event end date"),
+                "data_type": "date",
             },
         ]
     elif object_type == "order_position":
@@ -41,12 +94,124 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
             raise ValueError("event is required when object_type is 'order_position'")
 
         fields = [
-            {"key": "attendee_name", "label": _("Attendee name"), "data_type": "text"},
+            # Direct fields on OrderPosition (AbstractPosition)
+            {
+                "key": "attendee_name",
+                "label": _("Attendee name"),
+                "data_type": "text",
+            },  # Extract via: position.attendee_name
+            {
+                "key": "attendee_given_name",
+                "label": _("Attendee given name"),
+                "data_type": "text",
+            },  # Extract via: position.attendee_name_parts.get('given_name')
+            {
+                "key": "attendee_family_name",
+                "label": _("Attendee family name"),
+                "data_type": "text",
+            },  # Extract via: position.attendee_name_parts.get('family_name')
             {
                 "key": "attendee_email",
                 "label": _("Attendee email"),
                 "data_type": "text",
-            },
+            },  # Extract via: position.attendee_email
+            {
+                "key": "company",
+                "label": _("Company"),
+                "data_type": "text",
+            },  # Extract via: position.company
+            {
+                "key": "street",
+                "label": _("Street"),
+                "data_type": "text",
+            },  # Extract via: position.street
+            {
+                "key": "zipcode",
+                "label": _("Zipcode"),
+                "data_type": "text",
+            },  # Extract via: position.zipcode
+            {
+                "key": "city",
+                "label": _("City"),
+                "data_type": "text",
+            },  # Extract via: position.city
+            {
+                "key": "country",
+                "label": _("Country"),
+                "data_type": "text",
+            },  # Extract via: str(position.country) if position.country else None
+            {
+                "key": "state",
+                "label": _("State"),
+                "data_type": "text",
+            },  # Extract via: position.state
+            {
+                "key": "voucher",
+                "label": _("Voucher code"),
+                "data_type": "text",
+            },  # Extract via: position.voucher.code if position.voucher else None
+            {
+                "key": "price",
+                "label": _("Ticket price"),
+                "data_type": "number",
+            },  # Extract via: position.price
+            {
+                "key": "positionid",
+                "label": _("Position ID"),
+                "data_type": "number",
+            },  # Extract via: position.positionid
+            {
+                "key": "secret",
+                "label": _("Ticket secret"),
+                "data_type": "text",
+            },  # Extract via: position.secret
+            # Fields via item/product relationship
+            {
+                "key": "item_name",
+                "label": _("Product name"),
+                "data_type": "text",
+            },  # Extract via: position.item.name
+            {
+                "key": "item_admission",
+                "label": _("Is admission"),
+                "data_type": "yes/no",
+            },  # Extract via: position.item.admission
+            # Fields via order relationship
+            {
+                "key": "order_code",
+                "label": _("Order code"),
+                "data_type": "text",
+            },  # Extract via: position.order.code
+            {
+                "key": "order_email",
+                "label": _("Order email"),
+                "data_type": "text",
+            },  # Extract via: position.order.email
+            {
+                "key": "order_email_domain",
+                "label": _("Order email domain"),
+                "data_type": "text",
+            },  # Extract via: position.order.email.split('@')[-1] if position.order.email else None
+            {
+                "key": "order_total",
+                "label": _("Order total"),
+                "data_type": "number",
+            },  # Extract via: position.order.total
+            {
+                "key": "order_status",
+                "label": _("Order status"),
+                "data_type": "text",
+            },  # Extract via: position.order.status
+            {
+                "key": "order_datetime",
+                "label": _("Order datetime"),
+                "data_type": "date",
+            },  # Extract via: position.order.datetime
+            {
+                "key": "order_locale",
+                "label": _("Order locale"),
+                "data_type": "text",
+            },  # Extract via: position.order.locale
         ]
 
         questions = event.questions.filter(active=True)

--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -6,7 +6,7 @@ QUESTION_TYPE_MAP = {
     Question.TYPE_BOOLEAN: "yes/no",
     Question.TYPE_DATE: "date",
     Question.TYPE_DATETIME: "date",
-    Question.TYPE_TIME: "date",
+    Question.TYPE_TIME: "text",
     Question.TYPE_CHOICE_MULTIPLE: "text",
     Question.TYPE_CHOICE: "text",
     Question.TYPE_STRING: "text",
@@ -31,171 +31,171 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                 "key": "code",
                 "label": _("Order code"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "status",
                 "label": _("Order status"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "total",
                 "label": _("Order total"),
                 "data_type": "number",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "datetime",
                 "label": _("Order date and time"),
                 "data_type": "date",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "email",
                 "label": _("Order email"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "email_domain",
                 "label": _("Order email domain"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "event_and_order_code",
                 "label": _("Event and order code"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "payment_datetime",
                 "label": _("Payment date and time"),
                 "data_type": "date",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "locale",
                 "label": _("Order locale"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "order_link",
                 "label": _("Order link"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "phone",
                 "label": _("Order phone"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "comment",
                 "label": _("Order comment"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             {
                 "key": "testmode",
                 "label": _("Is test mode"),
                 "data_type": "yes/no",
-                "category": "Order details",
+                "category": _("Order details"),
             },
             # Invoice fields
             {
                 "key": "invoice_name",
                 "label": _("Invoice address name"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_company",
                 "label": _("Invoice address company"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_given_name",
                 "label": _("Invoice given name"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_family_name",
                 "label": _("Invoice family name"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_street",
                 "label": _("Invoice street"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_zip",
                 "label": _("Invoice zip code"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_city",
                 "label": _("Invoice city"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_country",
                 "label": _("Invoice country"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_state",
                 "label": _("Invoice state"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_vat_id",
                 "label": _("Invoice VAT ID"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             {
                 "key": "invoice_is_business",
                 "label": _("Invoice is business"),
                 "data_type": "yes/no",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },
             # Event information
             {
                 "key": "event_slug",
                 "label": _("Event short form"),
                 "data_type": "text",
-                "category": "Event information",
+                "category": _("Event information"),
             },
             {
                 "key": "event_name",
                 "label": _("Event name"),
                 "data_type": "text",
-                "category": "Event information",
+                "category": _("Event information"),
             },
             {
                 "key": "event_start_date",
                 "label": _("Event start date"),
                 "data_type": "date",
-                "category": "Event information",
+                "category": _("Event information"),
             },
             {
                 "key": "event_end_date",
                 "label": _("Event end date"),
                 "data_type": "date",
-                "category": "Event information",
+                "category": _("Event information"),
             },
         ]
     elif object_type == "order_position":
@@ -208,209 +208,234 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                 "key": "attendee_name",
                 "label": _("Attendee name"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.attendee_name
             {
                 "key": "attendee_given_name",
                 "label": _("Attendee given name"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.attendee_name_parts.get('given_name')
             {
                 "key": "attendee_family_name",
                 "label": _("Attendee family name"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.attendee_name_parts.get('family_name')
             {
                 "key": "attendee_email",
                 "label": _("Attendee email"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.attendee_email
             {
                 "key": "company",
                 "label": _("Company"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.company
             {
                 "key": "job_title",
                 "label": _("Job title"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.job_title
             {
                 "key": "street",
                 "label": _("Street"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.street
             {
                 "key": "zipcode",
                 "label": _("Zipcode"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.zipcode
             {
                 "key": "city",
                 "label": _("City"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.city
             {
                 "key": "country",
                 "label": _("Country"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: str(position.country) if position.country else None
             {
                 "key": "state",
                 "label": _("State"),
                 "data_type": "text",
-                "category": "Attendee details",
+                "category": _("Attendee details"),
             },  # Extract via: position.state
             {
                 "key": "voucher",
                 "label": _("Voucher code"),
                 "data_type": "text",
-                "category": "Ticket details",
+                "category": _("Ticket details"),
             },  # Extract via: position.voucher.code if position.voucher else None
             {
                 "key": "price",
                 "label": _("Ticket price"),
                 "data_type": "number",
-                "category": "Ticket details",
+                "category": _("Ticket details"),
             },  # Extract via: position.price
             {
                 "key": "positionid",
                 "label": _("Position ID"),
                 "data_type": "number",
-                "category": "Ticket details",
+                "category": _("Ticket details"),
             },  # Extract via: position.positionid
             {
                 "key": "secret",
                 "label": _("Ticket secret"),
                 "data_type": "text",
-                "category": "Ticket details",
+                "category": _("Ticket details"),
             },  # Extract via: position.secret
             # Fields via item/product relationship
             {
                 "key": "item_name",
                 "label": _("Product name"),
                 "data_type": "text",
-                "category": "Ticket details",
+                "category": _("Ticket details"),
             },  # Extract via: position.item.name
             {
                 "key": "item_admission",
                 "label": _("Is admission"),
                 "data_type": "yes/no",
-                "category": "Ticket details",
+                "category": _("Ticket details"),
             },  # Extract via: position.item.admission
             # Fields via order relationship
             {
                 "key": "order_code",
                 "label": _("Order code"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.code
             {
                 "key": "order_email",
                 "label": _("Order email"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.email
             {
                 "key": "order_email_domain",
                 "label": _("Order email domain"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.email.split('@')[-1] if position.order.email else None
             {
                 "key": "order_total",
                 "label": _("Order total"),
                 "data_type": "number",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.total
             {
                 "key": "order_status",
                 "label": _("Order status"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.status
             {
                 "key": "order_datetime",
                 "label": _("Order datetime"),
                 "data_type": "date",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.datetime
             {
                 "key": "order_locale",
                 "label": _("Order locale"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.locale
             {
                 "key": "order_phone",
                 "label": _("Order phone"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.phone
             {
                 "key": "order_comment",
                 "label": _("Order comment"),
                 "data_type": "text",
-                "category": "Order details",
+                "category": _("Order details"),
             },  # Extract via: position.order.comment
             # Invoice fields via order relationship
             {
                 "key": "invoice_name",
                 "label": _("Invoice address name"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.name
             {
                 "key": "invoice_company",
                 "label": _("Invoice address company"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.company
             {
                 "key": "invoice_street",
                 "label": _("Invoice street"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.street
             {
                 "key": "invoice_zip",
                 "label": _("Invoice zip code"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.zipcode
             {
                 "key": "invoice_city",
                 "label": _("Invoice city"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.city
             {
                 "key": "invoice_country",
                 "label": _("Invoice country"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.country
             {
                 "key": "invoice_state",
                 "label": _("Invoice state"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.state
             {
                 "key": "invoice_vat_id",
                 "label": _("Invoice VAT ID"),
                 "data_type": "text",
-                "category": "Invoice details",
+                "category": _("Invoice details"),
             },  # Extract via: position.order.invoice_address.vat_id
+            # Event information
+            {
+                "key": "event_slug",
+                "label": _("Event short form"),
+                "data_type": "text",
+                "category": _("Event information"),
+            },
+            {
+                "key": "event_name",
+                "label": _("Event name"),
+                "data_type": "text",
+                "category": _("Event information"),
+            },
+            {
+                "key": "event_start_date",
+                "label": _("Event start date"),
+                "data_type": "date",
+                "category": _("Event information"),
+            },
+            {
+                "key": "event_end_date",
+                "label": _("Event end date"),
+                "data_type": "date",
+                "category": _("Event information"),
+            },
         ]
 
         questions = event.questions.filter(active=True)
@@ -425,7 +450,7 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                     "key": f"question_{q.identifier}",
                     "label": str(q.question),
                     "data_type": data_type,
-                    "category": "Questions",
+                    "category": _("Questions"),
                 }
             )
 

--- a/hubspot/field_discovery.py
+++ b/hubspot/field_discovery.py
@@ -82,6 +82,24 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                 "label": _("Invoice country"),
                 "data_type": "text",
             },
+            {
+                "key": "invoice_state",
+                "label": _("Invoice state"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_vat_id",
+                "label": _("Invoice VAT ID"),
+                "data_type": "text",
+            },
+            {
+                "key": "invoice_is_business",
+                "label": _("Invoice is business"),
+                "data_type": "yes/no",
+            },
+            {"key": "phone", "label": _("Order phone"), "data_type": "text"},
+            {"key": "comment", "label": _("Order comment"), "data_type": "text"},
+            {"key": "testmode", "label": _("Is test mode"), "data_type": "yes/no"},
             # Event information
             {"key": "event_slug", "label": _("Event short form"), "data_type": "text"},
             {"key": "event_name", "label": _("Event name"), "data_type": "text"},
@@ -127,6 +145,11 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                 "label": _("Company"),
                 "data_type": "text",
             },  # Extract via: position.company
+            {
+                "key": "job_title",
+                "label": _("Job title"),
+                "data_type": "text",
+            },  # Extract via: position.job_title
             {
                 "key": "street",
                 "label": _("Street"),
@@ -219,6 +242,57 @@ def get_available_fields(object_type: str, event=None) -> list[dict]:
                 "label": _("Order locale"),
                 "data_type": "text",
             },  # Extract via: position.order.locale
+            {
+                "key": "order_phone",
+                "label": _("Order phone"),
+                "data_type": "text",
+            },  # Extract via: position.order.phone
+            {
+                "key": "order_comment",
+                "label": _("Order comment"),
+                "data_type": "text",
+            },  # Extract via: position.order.comment
+            # Invoice fields via order relationship
+            {
+                "key": "invoice_name",
+                "label": _("Invoice address name"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.name
+            {
+                "key": "invoice_company",
+                "label": _("Invoice address company"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.company
+            {
+                "key": "invoice_street",
+                "label": _("Invoice street"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.street
+            {
+                "key": "invoice_zip",
+                "label": _("Invoice zip code"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.zipcode
+            {
+                "key": "invoice_city",
+                "label": _("Invoice city"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.city
+            {
+                "key": "invoice_country",
+                "label": _("Invoice country"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.country
+            {
+                "key": "invoice_state",
+                "label": _("Invoice state"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.state
+            {
+                "key": "invoice_vat_id",
+                "label": _("Invoice VAT ID"),
+                "data_type": "text",
+            },  # Extract via: position.order.invoice_address.vat_id
         ]
 
         questions = event.questions.filter(active=True)

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -21,11 +21,25 @@ def test_get_available_fields_order():
     assert "total" in keys
     assert "datetime" in keys
     assert "email" in keys
+    assert "email_domain" in keys
+    assert "event_and_order_code" in keys
+    assert "payment_datetime" in keys
+    assert "locale" in keys
+    assert "order_link" in keys
 
     # Invoice address fields
     assert "invoice_name" in keys
     assert "invoice_company" in keys
-    assert "invoice_address" in keys
+    assert "invoice_given_name" in keys
+    assert "invoice_family_name" in keys
+    assert "invoice_street" in keys
+    assert "invoice_zip" in keys
+    assert "invoice_city" in keys
+    assert "invoice_country" in keys
+
+    # Event fields
+    assert "event_slug" in keys
+    assert "event_name" in keys
 
     # Validate structure
     for field in fields:
@@ -99,12 +113,16 @@ def test_get_available_fields_order_position_with_event(event):
 
         fields = get_available_fields("order_position", event=event)
 
-    # Should have 2 base fields + 5 active questions (N, B, D, S, M)
-    assert len(fields) == 7
+    # Should have 23 base fields + 5 active questions (N, B, D, S, M)
+    assert len(fields) == 28
 
     keys = [f["key"] for f in fields]
     assert "attendee_name" in keys
     assert "attendee_email" in keys
+    assert "company" in keys
+    assert "price" in keys
+    assert "order_code" in keys
+    assert "item_name" in keys
 
     # Find question fields
     question_fields = [f for f in fields if f["key"].startswith("question_")]

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -1,0 +1,132 @@
+import pytest
+from eventyay.base.models import Question
+
+from hubspot.field_discovery import get_available_fields
+
+
+@pytest.mark.django_db
+def test_get_available_fields_order():
+    fields = get_available_fields("order")
+
+    # Check that we get a non-empty list
+    assert isinstance(fields, list)
+    assert len(fields) > 0
+
+    # Extract keys for easy checking
+    keys = [f["key"] for f in fields]
+
+    # Standard fields
+    assert "code" in keys
+    assert "status" in keys
+    assert "total" in keys
+    assert "datetime" in keys
+    assert "email" in keys
+
+    # Invoice address fields
+    assert "invoice_name" in keys
+    assert "invoice_company" in keys
+    assert "invoice_address" in keys
+
+    # Validate structure
+    for field in fields:
+        assert "key" in field
+        assert "label" in field
+        assert "data_type" in field
+        assert field["key"]
+        assert field["label"]
+        assert field["data_type"] in ("text", "number", "date", "yes/no")
+
+
+@pytest.mark.django_db
+def test_get_available_fields_order_position_no_event():
+    with pytest.raises(
+        ValueError, match="event is required when object_type is 'order_position'"
+    ):
+        get_available_fields("order_position")
+
+
+@pytest.mark.django_db
+def test_get_available_fields_order_position_with_event(event):
+    from django_scopes import scope
+
+    with scope(organizer=event.organizer):
+        # Create some questions for the event
+        Question.objects.create(
+            event=event,
+            question="What is your age?",
+            type="N",
+            active=True,
+        )
+        Question.objects.create(
+            event=event,
+            question="Do you like Python?",
+            type="B",
+            active=True,
+        )
+        Question.objects.create(
+            event=event,
+            question="When is your birthday?",
+            type="D",
+            active=True,
+        )
+        Question.objects.create(
+            event=event,
+            question="What is your hobby?",
+            type="S",
+            active=True,
+        )
+        # Create an inactive question, should not be included
+        Question.objects.create(
+            event=event,
+            question="Inactive question",
+            type="S",
+            active=False,
+        )
+        # File upload question, should not be included
+        Question.objects.create(
+            event=event,
+            question="Upload file",
+            type="F",
+            active=True,
+        )
+        # Multiple choice question, mapped to text
+        Question.objects.create(
+            event=event,
+            question="Multiple choice",
+            type="M",
+            active=True,
+        )
+
+        fields = get_available_fields("order_position", event=event)
+
+    # Should have 2 base fields + 5 active questions (N, B, D, S, M)
+    assert len(fields) == 7
+
+    keys = [f["key"] for f in fields]
+    assert "attendee_name" in keys
+    assert "attendee_email" in keys
+
+    # Find question fields
+    question_fields = [f for f in fields if f["key"].startswith("question_")]
+    assert len(question_fields) == 5
+
+    # Check data types mapping
+    types_found = {f["data_type"] for f in question_fields}
+    assert "number" in types_found
+    assert "yes/no" in types_found
+    assert "date" in types_found
+    assert "text" in types_found
+
+    # Validate structure of all fields
+    for field in fields:
+        assert "key" in field
+        assert "label" in field
+        assert "data_type" in field
+        assert field["key"]
+        assert field["label"]
+        assert field["data_type"] in ("text", "number", "date", "yes/no")
+
+
+def test_get_available_fields_invalid_type():
+    with pytest.raises(ValueError, match="Unknown object_type: 'invalid_type'"):
+        get_available_fields("invalid_type")

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -60,6 +60,20 @@ def test_get_available_fields_order_position_no_event():
 
 
 @pytest.mark.django_db
+def test_get_available_fields_order_position_empty_event(event):
+    # Event without any questions defined
+    from django_scopes import scope
+
+    with scope(organizer=event.organizer):
+        fields = get_available_fields("order_position", event=event)
+
+    # Base fields are 38, and no question fields are appended
+    assert len(fields) == 38
+    question_fields = [f for f in fields if f["key"].startswith("question_")]
+    assert len(question_fields) == 0
+
+
+@pytest.mark.django_db
 def test_get_available_fields_order_position_with_event(event):
     from django_scopes import scope
 

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -113,8 +113,8 @@ def test_get_available_fields_order_position_with_event(event):
 
         fields = get_available_fields("order_position", event=event)
 
-    # Should have 34 base fields + 5 active questions (N, B, D, S, M)
-    assert len(fields) == 39
+    # Should have 38 base fields + 5 active questions (N, B, D, S, M)
+    assert len(fields) == 43
 
     keys = [f["key"] for f in fields]
     assert "attendee_name" in keys

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -113,8 +113,8 @@ def test_get_available_fields_order_position_with_event(event):
 
         fields = get_available_fields("order_position", event=event)
 
-    # Should have 23 base fields + 5 active questions (N, B, D, S, M)
-    assert len(fields) == 28
+    # Should have 34 base fields + 5 active questions (N, B, D, S, M)
+    assert len(fields) == 39
 
     keys = [f["key"] for f in fields]
     assert "attendee_name" in keys


### PR DESCRIPTION
## Closes #16

- This PR implements the Eventyay field discovery service, which inspects Order and OrderPosition objects to return a consistent list of properties for the #18
- This lays the critical groundwork for the `synchronization engine (Phase 4)`, allowing the frontend to dynamically populate its dropdowns with all available Eventyay data properties and their respective data types.

## Summary by Sourcery

Add a field discovery utility for HubSpot integrations to expose available order and order position fields, backed by tests.

New Features:
- Introduce get_available_fields to list supported order and order_position fields for HubSpot syncing, including invoice details and event questions.

Tests:
- Add tests covering available order fields, event-scoped order_position fields, validation of field metadata structure, and error handling for invalid object types or missing events.