### PR TITLE
feat: hubspot property fetching and caching

### DIFF
--- a/hubspot/services.py
+++ b/hubspot/services.py
@@ -2,6 +2,7 @@ import datetime
 import os
 
 import requests
+from django.core.cache import cache
 from django.db import transaction
 from django.utils.timezone import now
 from django_scopes import scope
@@ -15,6 +16,69 @@ from .models import (
     SyncLog,
     SyncStatus,
 )
+
+
+class HubSpotFetchError(Exception):
+    """Raised when fetching data from HubSpot API fails."""
+
+    pass
+
+
+def get_hubspot_properties(event, object_type: str) -> list[dict]:
+    """
+    Fetches and caches all properties for a given HubSpot object type (contact or deal).
+    Returns a list of dictionaries with 'key', 'label', and 'data_type'.
+    """
+    cache_key = f"hubspot_properties_{event.id}_{object_type}"
+    cached_props = cache.get(cache_key)
+    if cached_props is not None:
+        return cached_props
+
+    token = get_valid_hubspot_token(event)
+    if not token:
+        raise HubSpotFetchError("Not connected to HubSpot or token is invalid.")
+
+    url = f"https://api.hubapi.com/crm/v3/properties/{object_type}"
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        response = requests.get(url, headers=headers, timeout=15)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise HubSpotFetchError(f"Failed to fetch properties from HubSpot: {str(e)}")
+
+    data = response.json()
+    results = data.get("results", [])
+
+    properties = []
+    for prop in results:
+        # HubSpot's API returns internal/hidden properties by default.
+        # We skip them to match the 210 visible properties in the HubSpot UI.
+        if prop.get("hidden"):
+            continue
+
+        hubspot_type = prop.get("type", "string")
+
+        # Map HubSpot types to eventyay field types ("text", "number", "date", "yes/no")
+        if hubspot_type == "number":
+            data_type = "number"
+        elif hubspot_type in ("date", "datetime"):
+            data_type = "date"
+        elif hubspot_type == "bool":
+            data_type = "yes/no"
+        else:
+            data_type = "text"
+
+        properties.append(
+            {
+                "key": prop.get("name"),
+                "label": prop.get("label"),
+                "data_type": data_type,
+            }
+        )
+
+    cache.set(cache_key, properties, timeout=3600)
+    return properties
 
 
 def get_valid_hubspot_token(event) -> str | None:

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -7,6 +7,7 @@ import requests
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
@@ -284,6 +285,10 @@ class EventHubSpotDisconnectView(EventPermissionRequiredMixin, View):
                 action=AuditAction.DISCONNECT,
                 ip_address=get_client_ip(request),
             )
+
+        # Clear cached HubSpot properties
+        cache.delete(f"hubspot_properties_{request.event.id}_contact")
+        cache.delete(f"hubspot_properties_{request.event.id}_deal")
 
         messages.success(request, _("Successfully disconnected from HubSpot."))
         return redirect(settings_url)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,7 +6,11 @@ from django.utils.timezone import now
 from django_scopes import scope
 
 from hubspot.models import HubSpotOAuthToken
-from hubspot.services import get_valid_hubspot_token
+from hubspot.services import (
+    get_valid_hubspot_token,
+    get_hubspot_properties,
+    HubSpotFetchError,
+)
 
 
 @pytest.fixture
@@ -74,3 +78,84 @@ def test_concurrent_refresh_attempts(mock_post, event, hubspot_token):
             get_valid_hubspot_token(event)
 
         mock_sfu.assert_called_once()
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.services.requests.get")
+def test_get_hubspot_properties_success_and_cache(mock_get, event, hubspot_token):
+    from django.core.cache import cache
+
+    cache.clear()
+
+    mock_response = mock.Mock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "results": [
+            {"name": "firstname", "label": "First Name", "type": "string"},
+            {"name": "age", "label": "Age", "type": "number"},
+            {"name": "createdate", "label": "Create Date", "type": "datetime"},
+            {"name": "is_active", "label": "Is Active", "type": "bool"},
+        ]
+    }
+    mock_get.return_value = mock_response
+
+    with scope(organizer=event.organizer):
+        properties = get_hubspot_properties(event, "contact")
+
+    assert len(properties) == 4
+    assert properties[0] == {
+        "key": "firstname",
+        "label": "First Name",
+        "data_type": "text",
+    }
+    assert properties[1] == {"key": "age", "label": "Age", "data_type": "number"}
+    assert properties[2] == {
+        "key": "createdate",
+        "label": "Create Date",
+        "data_type": "date",
+    }
+    assert properties[3] == {
+        "key": "is_active",
+        "label": "Is Active",
+        "data_type": "yes/no",
+    }
+
+    mock_get.assert_called_once()
+
+    # Second call should use cache and not hit API
+    with scope(organizer=event.organizer):
+        properties2 = get_hubspot_properties(event, "contact")
+
+    assert properties == properties2
+    mock_get.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_get_hubspot_properties_no_token(event):
+    from django.core.cache import cache
+
+    cache.clear()
+
+    with scope(organizer=event.organizer):
+        with pytest.raises(
+            HubSpotFetchError, match="Not connected to HubSpot or token is invalid"
+        ):
+            get_hubspot_properties(event, "contact")
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.services.requests.get")
+def test_get_hubspot_properties_api_failure(mock_get, event, hubspot_token):
+    from django.core.cache import cache
+
+    cache.clear()
+
+    import requests
+
+    mock_get.side_effect = requests.RequestException("API error")
+
+    with scope(organizer=event.organizer):
+        with pytest.raises(
+            HubSpotFetchError, match="Failed to fetch properties from HubSpot"
+        ):
+            get_hubspot_properties(event, "contact")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -75,6 +75,11 @@ def test_hubspot_disconnect_view_connected(
     mock_response.ok = True
     mock_delete.return_value = mock_response
 
+    from django.core.cache import cache
+
+    cache.set(f"hubspot_properties_{event.id}_contact", [{"key": "test"}])
+    cache.set(f"hubspot_properties_{event.id}_deal", [{"key": "test"}])
+
     url = reverse(
         "plugins:hubspot:disconnect",
         kwargs={"organizer": organizer.slug, "event": event.slug},
@@ -89,6 +94,9 @@ def test_hubspot_disconnect_view_connected(
 
     with scope(organizer=event.organizer):
         assert not HubSpotOAuthToken.objects.filter(event=event).exists()
+
+    assert cache.get(f"hubspot_properties_{event.id}_contact") is None
+    assert cache.get(f"hubspot_properties_{event.id}_deal") is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Close #17 

- This PR implements the backend service logic for fetching, caching, and standardizing property fields from an organizer's connected HubSpot portal. These properties will be consumed by the upcoming Field Mapping UI to allow organizers to map Eventyay fields to HubSpot properties (Issue #18).


## Steps to test

- Run the following with the virtual env enable in your terminal.

```bash
python manage.py shell -c "
from hubspot.models import HubSpotOAuthToken
from hubspot.services import get_hubspot_properties
from django_scopes import scope, scopes_disabled
import json
import os

with scopes_disabled():
    token = HubSpotOAuthToken.objects.first()

if token:
    with scope(organizer=token.event.organizer):
        from django.core.cache import cache
        # Clear the old cached properties to force a fresh fetch
        cache.delete(f'hubspot_properties_{token.event.id}_contact')
        
        props = get_hubspot_properties(token.event, 'contact')
        
        # Save to the current working directory where the command was run
        out_path = os.path.join(os.getcwd(), 'hubspot_properties.txt')
        
        with open(out_path, 'w') as f:
            f.write(f'Total properties fetched: {len(props)}\n\n')
            json.dump(props, f, indent=2)
            
        print(f'Successfully wrote {len(props)} properties to {out_path}')
else:
    print('No event connected to HubSpot was found.')
"
```

- After running the command, a file "hubspot_properties.txt" will be generated containing all the hubspot properties you have.
- Note : This test required you to have the any one event connected to hubspot, so that it can use it's token


## Video Demo

- Connecting the event to hubspot

https://github.com/user-attachments/assets/4ba9edc0-1ffb-4ad4-ae98-dfaac394f032


- Creating a new property in hubspot

https://github.com/user-attachments/assets/b3b74676-e455-48e0-85cf-1655540265f8


- Fetching that property and showing it in our local system

https://github.com/user-attachments/assets/4d95438f-5cf4-4a3f-babe-686effde7b7e


