### PR TITLE
feat: hubspot api client

### DIFF
--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -1,0 +1,155 @@
+import logging
+import re
+import requests
+
+from .services import get_valid_hubspot_token
+
+logger = logging.getLogger(__name__)
+
+
+class HubSpotAPIError(Exception):
+    """Base for all HubSpot API errors."""
+
+    def __init__(self, message, status_code=None, response_body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class HubSpotTransientError(HubSpotAPIError):
+    """5xx, 429, timeouts — safe to retry."""
+
+    def __init__(
+        self, message, status_code=None, response_body=None, retry_after_seconds=None
+    ):
+        super().__init__(message, status_code, response_body)
+        self.retry_after_seconds = retry_after_seconds
+
+
+class HubSpotPermanentError(HubSpotAPIError):
+    """4xx (except 409) — do not retry."""
+
+    pass
+
+
+def _raise_for_status(response: requests.Response) -> None:
+    """Raise HubSpotTransientError or HubSpotPermanentError based on status code."""
+    if response.ok:
+        return
+
+    status_code = response.status_code
+    response_body = None
+    try:
+        response_body = response.json()
+    except ValueError:
+        response_body = response.text
+
+    message = f"HubSpot API error: {status_code} {response.reason}"
+    if isinstance(response_body, dict) and "message" in response_body:
+        message += f" - {response_body['message']}"
+
+    if status_code in (429, 500, 502, 503, 504):
+        retry_after = response.headers.get("Retry-After")
+        retry_after_seconds = None
+        if retry_after:
+            try:
+                retry_after_seconds = int(retry_after)
+            except ValueError:
+                pass
+        raise HubSpotTransientError(
+            message=message,
+            status_code=status_code,
+            response_body=response_body,
+            retry_after_seconds=retry_after_seconds,
+        )
+
+    raise HubSpotPermanentError(
+        message=message,
+        status_code=status_code,
+        response_body=response_body,
+    )
+
+
+def update_record(event, object_type: str, record_id: str, properties: dict) -> str:
+    """
+    Updates an existing HubSpot record.
+    Raises HubSpotTransientError or HubSpotPermanentError on failure.
+    Returns the record ID on success.
+    """
+    token = get_valid_hubspot_token(event)
+    if not token:
+        raise HubSpotPermanentError("Not connected to HubSpot or token is invalid.")
+
+    url = f"https://api.hubapi.com/crm/v3/objects/{object_type}/{record_id}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {"properties": properties}
+
+    try:
+        response = requests.patch(url, headers=headers, json=payload, timeout=15)
+    except requests.exceptions.Timeout as e:
+        raise HubSpotTransientError(f"Request to HubSpot timed out: {e}")
+    except requests.exceptions.ConnectionError as e:
+        raise HubSpotTransientError(f"Connection to HubSpot failed: {e}")
+    except requests.exceptions.RequestException as e:
+        raise HubSpotTransientError(f"Request to HubSpot failed: {e}")
+
+    _raise_for_status(response)
+    return str(record_id)
+
+
+def create_record(event, object_type: str, properties: dict) -> str:
+    """
+    Creates a new HubSpot record.
+    If a 409 Conflict is returned with an existing ID, falls back to updating that record.
+    Raises HubSpotTransientError or HubSpotPermanentError on failure.
+    Returns the new or updated record ID on success.
+    """
+    token = get_valid_hubspot_token(event)
+    if not token:
+        raise HubSpotPermanentError("Not connected to HubSpot or token is invalid.")
+
+    url = f"https://api.hubapi.com/crm/v3/objects/{object_type}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {"properties": properties}
+
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=15)
+    except requests.exceptions.Timeout as e:
+        raise HubSpotTransientError(f"Request to HubSpot timed out: {e}")
+    except requests.exceptions.ConnectionError as e:
+        raise HubSpotTransientError(f"Connection to HubSpot failed: {e}")
+    except requests.exceptions.RequestException as e:
+        raise HubSpotTransientError(f"Request to HubSpot failed: {e}")
+
+    # Handle 409 Conflict specifically for fallback
+    if response.status_code == 409:
+        try:
+            response_body = response.json()
+        except ValueError:
+            response_body = response.text
+
+        error_msg = (
+            response_body.get("message", "")
+            if isinstance(response_body, dict)
+            else str(response_body)
+        )
+        match = re.search(r"Existing ID:\s*(\d+)", error_msg)
+
+        if match:
+            existing_id = match.group(1)
+            logger.info(
+                f"HubSpot 409 Conflict for {object_type}. Falling back to update for ID {existing_id}."
+            )
+            return update_record(event, object_type, existing_id, properties)
+        else:
+            # If we get a 409 but can't extract the ID, treat it as a permanent error
+            raise HubSpotPermanentError(
+                message=f"HubSpot API conflict error but unable to extract existing ID: {error_msg}",
+                status_code=409,
+                response_body=response_body,
+            )
+
+    # Handle other statuses via the common helper
+    _raise_for_status(response)
+
+    return str(response.json()["id"])

--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -35,8 +35,6 @@ class HubSpotPermanentError(HubSpotAPIError):
 class HubSpotRecordNotFoundError(HubSpotPermanentError):
     """404 Not Found — record was deleted in HubSpot."""
 
-    """4xx (except 409) — do not retry."""
-
     pass
 
 
@@ -94,6 +92,10 @@ def update_record(event, object_type: str, record_id: str, properties: dict) -> 
     if not token:
         raise HubSpotPermanentError("Not connected to HubSpot or token is invalid.")
 
+    object_type = {"contact": "contacts", "deal": "deals"}.get(object_type, object_type)
+    if object_type not in {"contacts", "deals"}:
+        raise HubSpotPermanentError(f"Unsupported HubSpot object type: {object_type}")
+
     url = f"https://api.hubapi.com/crm/v3/objects/{object_type}/{record_id}"
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
     payload = {"properties": properties}
@@ -121,6 +123,10 @@ def create_record(event, object_type: str, properties: dict) -> str:
     token = get_valid_hubspot_token(event)
     if not token:
         raise HubSpotPermanentError("Not connected to HubSpot or token is invalid.")
+
+    object_type = {"contact": "contacts", "deal": "deals"}.get(object_type, object_type)
+    if object_type not in {"contacts", "deals"}:
+        raise HubSpotPermanentError(f"Unsupported HubSpot object type: {object_type}")
 
     url = f"https://api.hubapi.com/crm/v3/objects/{object_type}"
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
@@ -178,6 +184,10 @@ def get_record(event, object_type: str, record_id: str, properties: list) -> dic
     token = get_valid_hubspot_token(event)
     if not token:
         raise HubSpotPermanentError("Not connected to HubSpot or token is invalid.")
+
+    object_type = {"contact": "contacts", "deal": "deals"}.get(object_type, object_type)
+    if object_type not in {"contacts", "deals"}:
+        raise HubSpotPermanentError(f"Unsupported HubSpot object type: {object_type}")
 
     url = f"https://api.hubapi.com/crm/v3/objects/{object_type}/{record_id}"
     headers = {"Authorization": f"Bearer {token}"}

--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -32,6 +32,14 @@ class HubSpotPermanentError(HubSpotAPIError):
     pass
 
 
+class HubSpotRecordNotFoundError(HubSpotPermanentError):
+    """404 Not Found — record was deleted in HubSpot."""
+
+    """4xx (except 409) — do not retry."""
+
+    pass
+
+
 def _raise_for_status(response: requests.Response) -> None:
     """Raise HubSpotTransientError or HubSpotPermanentError based on status code."""
     if response.ok:
@@ -63,6 +71,12 @@ def _raise_for_status(response: requests.Response) -> None:
             retry_after_seconds=retry_after_seconds,
         )
 
+    if status_code == 404:
+        raise HubSpotRecordNotFoundError(
+            message=message,
+            status_code=status_code,
+            response_body=response_body,
+        )
     raise HubSpotPermanentError(
         message=message,
         status_code=status_code,

--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -153,3 +153,31 @@ def create_record(event, object_type: str, properties: dict) -> str:
     _raise_for_status(response)
 
     return str(response.json()["id"])
+
+
+def get_record(event, object_type: str, record_id: str, properties: list) -> dict:
+    """
+    Fetches an existing HubSpot record to get its properties.
+    Raises HubSpotTransientError or HubSpotPermanentError on failure.
+    Returns the record's properties dict.
+    """
+    token = get_valid_hubspot_token(event)
+    if not token:
+        raise HubSpotPermanentError("Not connected to HubSpot or token is invalid.")
+
+    url = f"https://api.hubapi.com/crm/v3/objects/{object_type}/{record_id}"
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"properties": ",".join(properties)} if properties else {}
+
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=15)
+    except requests.exceptions.Timeout as e:
+        raise HubSpotTransientError(f"Request to HubSpot timed out: {e}")
+    except requests.exceptions.ConnectionError as e:
+        raise HubSpotTransientError(f"Connection to HubSpot failed: {e}")
+    except requests.exceptions.RequestException as e:
+        raise HubSpotTransientError(f"Request to HubSpot failed: {e}")
+
+    _raise_for_status(response)
+    data = response.json()
+    return data.get("properties", {})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ from hubspot.client import (
     HubSpotTransientError,
     create_record,
     update_record,
+    get_record,
 )
 from hubspot.models import HubSpotOAuthToken
 
@@ -40,7 +41,7 @@ def test_create_record_success(mock_post, event, hubspot_token):
     assert record_id == "12345"
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert "contacts" not in args[0]
+    assert "/crm/v3/objects/contacts" in args[0]
     assert kwargs["json"]["properties"] == {"firstname": "John"}
     assert kwargs["headers"]["Authorization"] == "Bearer old_access"
 
@@ -66,7 +67,7 @@ def test_update_record_success(mock_patch, event, hubspot_token):
     assert record_id == "12345"
     mock_patch.assert_called_once()
     args, kwargs = mock_patch.call_args
-    assert "12345" in args[0]
+    assert "/crm/v3/objects/contacts/12345" in args[0]
     assert kwargs["json"]["properties"] == {"firstname": "John"}
 
 
@@ -100,7 +101,7 @@ def test_create_409_falls_back_to_update(mock_patch, mock_post, event, hubspot_t
     mock_patch.assert_called_once()
 
     args, kwargs = mock_patch.call_args
-    assert "98765" in args[0]
+    assert "/crm/v3/objects/contacts/98765" in args[0]
 
 
 @pytest.mark.django_db
@@ -186,3 +187,39 @@ def test_connection_error_raises_transient(mock_post, event, hubspot_token):
 
     with pytest.raises(HubSpotTransientError, match="Connection to HubSpot failed"):
         create_record(event, "contact", {"firstname": "John"})
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.get")
+def test_get_record_success(mock_get, event, hubspot_token):
+    mock_response = mock.Mock()
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"properties": {"firstname": "John"}}
+    mock_get.return_value = mock_response
+
+    properties = get_record(event, "contact", "12345", ["firstname"])
+
+    assert properties == {"firstname": "John"}
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert "contacts" in args[0]
+    assert "12345" in args[0]
+    assert kwargs["params"] == {"properties": "firstname"}
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.get")
+def test_get_record_failure(mock_get, event, hubspot_token):
+    mock_response = mock.Mock()
+    mock_response.ok = False
+    mock_response.status_code = 500
+    mock_response.json.side_effect = ValueError()
+    mock_response.text = "Internal Server Error"
+    mock_response.headers = {}
+    mock_get.return_value = mock_response
+
+    with pytest.raises(HubSpotTransientError) as exc_info:
+        get_record(event, "contact", "12345", ["firstname"])
+
+    assert exc_info.value.status_code == 500

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,188 @@
+import datetime
+from unittest import mock
+
+import pytest
+import requests
+from django.utils.timezone import now
+from django_scopes import scope
+
+from hubspot.client import (
+    HubSpotPermanentError,
+    HubSpotTransientError,
+    create_record,
+    update_record,
+)
+from hubspot.models import HubSpotOAuthToken
+
+
+@pytest.fixture
+def hubspot_token(event):
+    with scope(organizer=event.organizer):
+        return HubSpotOAuthToken.objects.create(
+            event=event,
+            access_token="old_access",
+            refresh_token="old_refresh",
+            expires_at=now() + datetime.timedelta(hours=1),
+        )
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_create_record_success(mock_post, event, hubspot_token):
+    mock_response = mock.Mock()
+    mock_response.ok = True
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"id": "12345"}
+    mock_post.return_value = mock_response
+
+    record_id = create_record(event, "contact", {"firstname": "John"})
+
+    assert record_id == "12345"
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert "contacts" not in args[0]
+    assert kwargs["json"]["properties"] == {"firstname": "John"}
+    assert kwargs["headers"]["Authorization"] == "Bearer old_access"
+
+
+@pytest.mark.django_db
+def test_create_record_no_token(event, caplog):
+    # No token created
+    with pytest.raises(HubSpotPermanentError, match="Not connected to HubSpot"):
+        create_record(event, "contact", {"firstname": "John"})
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.patch")
+def test_update_record_success(mock_patch, event, hubspot_token):
+    mock_response = mock.Mock()
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "12345"}
+    mock_patch.return_value = mock_response
+
+    record_id = update_record(event, "contact", "12345", {"firstname": "John"})
+
+    assert record_id == "12345"
+    mock_patch.assert_called_once()
+    args, kwargs = mock_patch.call_args
+    assert "12345" in args[0]
+    assert kwargs["json"]["properties"] == {"firstname": "John"}
+
+
+@pytest.mark.django_db
+def test_update_record_no_token(event, caplog):
+    with pytest.raises(HubSpotPermanentError, match="Not connected to HubSpot"):
+        update_record(event, "contact", "12345", {"firstname": "John"})
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+@mock.patch("hubspot.client.requests.patch")
+def test_create_409_falls_back_to_update(mock_patch, mock_post, event, hubspot_token):
+    mock_post_response = mock.Mock()
+    mock_post_response.ok = False
+    mock_post_response.status_code = 409
+    mock_post_response.json.return_value = {
+        "message": "Contact already exists. Existing ID: 98765"
+    }
+    mock_post.return_value = mock_post_response
+
+    mock_patch_response = mock.Mock()
+    mock_patch_response.ok = True
+    mock_patch_response.status_code = 200
+    mock_patch.return_value = mock_patch_response
+
+    record_id = create_record(event, "contact", {"firstname": "John"})
+
+    assert record_id == "98765"
+    mock_post.assert_called_once()
+    mock_patch.assert_called_once()
+
+    args, kwargs = mock_patch.call_args
+    assert "98765" in args[0]
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_create_409_unparseable_id(mock_post, event, hubspot_token):
+    mock_post_response = mock.Mock()
+    mock_post_response.ok = False
+    mock_post_response.status_code = 409
+    mock_post_response.json.return_value = {"message": "Conflict without an ID"}
+    mock_post.return_value = mock_post_response
+
+    with pytest.raises(HubSpotPermanentError) as exc_info:
+        create_record(event, "contact", {"firstname": "John"})
+
+    assert exc_info.value.status_code == 409
+    assert "unable to extract existing ID" in str(exc_info.value)
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_5xx_raises_transient(mock_post, event, hubspot_token):
+    for status in [500, 502, 503, 504]:
+        mock_response = mock.Mock()
+        mock_response.ok = False
+        mock_response.status_code = status
+        mock_response.json.side_effect = ValueError()
+        mock_response.text = "Internal Server Error"
+        mock_response.headers = {}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HubSpotTransientError) as exc_info:
+            create_record(event, "contact", {"firstname": "John"})
+
+        assert exc_info.value.status_code == status
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_429_raises_transient_with_retry_after(mock_post, event, hubspot_token):
+    mock_response = mock.Mock()
+    mock_response.ok = False
+    mock_response.status_code = 429
+    mock_response.json.return_value = {"message": "Rate limit exceeded"}
+    mock_response.headers = {"Retry-After": "10"}
+    mock_post.return_value = mock_response
+
+    with pytest.raises(HubSpotTransientError) as exc_info:
+        create_record(event, "contact", {"firstname": "John"})
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.retry_after_seconds == 10
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_4xx_raises_permanent(mock_post, event, hubspot_token):
+    for status in [400, 401, 403, 404]:
+        mock_response = mock.Mock()
+        mock_response.ok = False
+        mock_response.status_code = status
+        mock_response.json.return_value = {"message": "Bad request"}
+        mock_post.return_value = mock_response
+
+        with pytest.raises(HubSpotPermanentError) as exc_info:
+            create_record(event, "contact", {"firstname": "John"})
+
+        assert exc_info.value.status_code == status
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_timeout_raises_transient(mock_post, event, hubspot_token):
+    mock_post.side_effect = requests.exceptions.Timeout("Timeout")
+
+    with pytest.raises(HubSpotTransientError, match="Request to HubSpot timed out"):
+        create_record(event, "contact", {"firstname": "John"})
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.client.requests.post")
+def test_connection_error_raises_transient(mock_post, event, hubspot_token):
+    mock_post.side_effect = requests.exceptions.ConnectionError("Connection error")
+
+    with pytest.raises(HubSpotTransientError, match="Connection to HubSpot failed"):
+        create_record(event, "contact", {"firstname": "John"})


### PR DESCRIPTION
## Closes #25 

This pr adds the client that actually talks to HubSpot — creating and updating Contacts and Deals using `requests`, consistent with the rest of the plugin.

## Tasks Covered

- [x] Add a client function that creates a HubSpot record (Contact or Deal) given an object type and a dict of properties, using the event's stored, valid access token
- [x] Add a client function that updates an existing HubSpot record by its HubSpot ID
- [x] On create, if HubSpot returns a 409 (record already exists), fall back to an update instead of treating it as a failure
- [x] Raise distinct, catchable errors for: transient failures (5xx, timeouts, 429 rate limit) vs. permanent failures (4xx other than 409)
- [x] Read the rate limit / retry-after header when present and respect it before any retry
- [x] Write tests covering: successful create, successful update, 409 falls back to update, 5xx raises a transient error, 4xx raises a permanent error, rate limit header is respected

## Steps to test
Run the command, and a record entry is created in the hubspot contacts
```bash
python manage.py shell << 'EOF'
from eventyay.base.models import Event
from hubspot.client import create_record
event = Event.objects.get(slug='gtavi')
properties = {
    'email': 'test.visual@example.com',
    'firstname': 'Visual',
    'lastname': 'Tester'
}
record_id = create_record(event, 'contact', properties)
print(f'\n\nSUCCESS! Created/Updated HubSpot Contact ID: {record_id}\n\n')
EOF
```
> [!NOTE] 
Remeber to change the `slug='gtavi'` to `slug=`{your-event-slug-that-is-connected-hubspot}'`

## Video Demo

https://github.com/user-attachments/assets/1d37052b-6d60-49cd-b4b1-9f18716c8bb7
