### PR TITLE
feat: tasks enqueing and order syncing

### DIFF
--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -38,6 +38,14 @@ class HubSpotRecordNotFoundError(HubSpotPermanentError):
     pass
 
 
+class HubSpotConflictError(HubSpotPermanentError):
+    """409 Conflict — record already exists."""
+
+    def __init__(self, message, existing_id, status_code=409, response_body=None):
+        super().__init__(message, status_code, response_body)
+        self.existing_id = existing_id
+
+
 def _raise_for_status(response: requests.Response) -> None:
     """Raise HubSpotTransientError or HubSpotPermanentError based on status code."""
     if response.ok:
@@ -158,9 +166,13 @@ def create_record(event, object_type: str, properties: dict) -> str:
         if match:
             existing_id = match.group(1)
             logger.info(
-                f"HubSpot 409 Conflict for {object_type}. Falling back to update for ID {existing_id}."
+                f"HubSpot 409 Conflict for {object_type}. Existing ID: {existing_id}."
             )
-            return update_record(event, object_type, existing_id, properties)
+            raise HubSpotConflictError(
+                message=f"HubSpot API conflict: record already exists with ID {existing_id}.",
+                existing_id=existing_id,
+                response_body=response_body,
+            )
         else:
             # If we get a 409 but can't extract the ID, treat it as a permanent error
             raise HubSpotPermanentError(

--- a/hubspot/services.py
+++ b/hubspot/services.py
@@ -119,6 +119,13 @@ def sync_hubspot_properties(event, object_type: str):
         for prop in results:
             if prop.get("hidden"):
                 continue
+
+            modification_metadata = prop.get("modificationMetadata", {})
+            if modification_metadata.get("readOnlyValue"):
+                continue
+
+            if prop.get("calculated"):
+                continue
             HubSpotProperty.objects.update_or_create(
                 event=event,
                 object_type=object_type,

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -3,8 +3,10 @@ from django.dispatch import receiver
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
 from eventyay.base.models import Order, OrderPosition
 from eventyay.base.signals import periodic_task
+from django.db import transaction
 from eventyay.control.signals import nav_event
 from django_scopes import scope
 from eventyay.base.signals import order_placed, order_paid, order_canceled
@@ -44,6 +46,10 @@ def control_nav_import(sender, request=None, **kwargs):
 def _enqueue_hubspot_sync(sender, order, **kwargs):
     if not order:
         return
+
+    if order.status != Order.STATUS_PAID:
+        return
+
     with scope(organizer=order.event.organizer):
         settings = HubSpotEventSettings.objects.filter(event=order.event).first()
         if not settings or not settings.sync_enabled:
@@ -51,7 +57,15 @@ def _enqueue_hubspot_sync(sender, order, **kwargs):
         if not HubSpotOAuthToken.objects.filter(event=order.event).exists():
             return
 
-    sync_order_to_hubspot.apply_async(args=[order.id, order.event.id], countdown=5)
+    def enqueue_task():
+        # Deduplicate multiple signals for the same order within a short window
+        cache_key = f"hubspot_sync_enqueued_{order.id}"
+        if cache.add(cache_key, "1", timeout=5):
+            sync_order_to_hubspot.apply_async(
+                args=[order.id, order.event.id], countdown=5
+            )
+
+    transaction.on_commit(enqueue_task)
 
 
 @receiver(order_placed, dispatch_uid="hubspot_order_placed")

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -6,10 +6,15 @@ from django.contrib.contenttypes.models import ContentType
 from eventyay.base.models import Order, OrderPosition
 from eventyay.base.signals import periodic_task
 from eventyay.control.signals import nav_event
+from django_scopes import scope
+from eventyay.base.signals import order_placed, order_paid, order_canceled
+from .tasks import sync_order_to_hubspot
 from .models import (
+    HubSpotEventSettings,
     ObjectTypeMapping,
     HubSpotFieldMapping,
     HubSpotObjectMapping,
+    HubSpotOAuthToken,
     AuditLog,
     SyncLog,
 )
@@ -34,6 +39,34 @@ def control_nav_import(sender, request=None, **kwargs):
             "icon": "bar-chart",
         }
     ]
+
+
+def _enqueue_hubspot_sync(sender, order, **kwargs):
+    if not order:
+        return
+    with scope(organizer=order.event.organizer):
+        settings = HubSpotEventSettings.objects.filter(event=order.event).first()
+        if not settings or not settings.sync_enabled:
+            return
+        if not HubSpotOAuthToken.objects.filter(event=order.event).exists():
+            return
+
+    sync_order_to_hubspot.apply_async(args=[order.id, order.event.id], countdown=5)
+
+
+@receiver(order_placed, dispatch_uid="hubspot_order_placed")
+def on_order_placed(sender, order, **kwargs):
+    _enqueue_hubspot_sync(sender, order, **kwargs)
+
+
+@receiver(order_paid, dispatch_uid="hubspot_order_paid")
+def on_order_paid(sender, order, **kwargs):
+    _enqueue_hubspot_sync(sender, order, **kwargs)
+
+
+@receiver(order_canceled, dispatch_uid="hubspot_order_canceled")
+def on_order_canceled(sender, order, **kwargs):
+    _enqueue_hubspot_sync(sender, order, **kwargs)
 
 
 @receiver(

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -1,0 +1,512 @@
+import logging
+from typing import Any, Dict
+
+from celery import shared_task
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.utils.timezone import now
+from django_scopes import scope, scopes_disabled
+from django.conf import settings
+from django.urls import reverse
+
+from eventyay.base.models import Event, Order, OrderPosition
+
+from .client import (
+    HubSpotTransientError,
+    HubSpotPermanentError,
+    HubSpotRecordNotFoundError,
+    HubSpotConflictError,
+    create_record,
+    update_record,
+    get_record,
+)
+from .services import get_valid_hubspot_token
+from .models import (
+    HubSpotEventSettings,
+    HubSpotFieldMapping,
+    HubSpotObjectMapping,
+    HubSpotProperty,
+    ObjectTypeMapping,
+    SyncAction,
+    SyncDirection,
+    SyncLog,
+    SyncMode,
+    SyncStatus,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_question_value(obj: Any, question_id: str) -> Any:
+    """Helper to get a question answer from an OrderPosition"""
+    if not isinstance(obj, OrderPosition):
+        return None
+    # We look for the answer to the specific question_id
+    # The identifier in field discovery is the Question.identifier.
+    for answer in obj.answers.all():
+        if answer.question.identifier == question_id:
+            # We return the string value. Type conversion handles the rest.
+            if answer.question.type == "B":
+                return answer.answer.lower() in ("true", "yes", "1")
+            return answer.answer
+    return None
+
+
+def _resolve_eventyay_field(obj: Any, key: str) -> Any:
+    """Helper to extract a specific field from Order or OrderPosition based on field_discovery keys"""
+    # Event fields
+    if key.startswith("event_"):
+        event = (
+            obj.event
+            if hasattr(obj, "event")
+            else (obj.order.event if hasattr(obj, "order") else None)
+        )
+        if not event:
+            return None
+        if key == "event_slug":
+            return event.slug
+        if key == "event_name":
+            return event.name
+        if key == "event_start_date":
+            return event.date_from
+        if key == "event_end_date":
+            return event.date_to
+        if key == "event_and_order_code":
+            order_code = obj.code if isinstance(obj, Order) else obj.order.code
+            return f"{event.slug}-{order_code}"
+
+    # Invoice fields
+    if key.startswith("invoice_"):
+        order = obj if isinstance(obj, Order) else obj.order
+        ia = getattr(order, "invoice_address", None)
+        if not ia:
+            return None
+
+        attr = key.replace("invoice_", "")
+        if attr == "name":
+            return ia.name
+        if attr == "company":
+            return ia.company
+        if attr == "given_name":
+            parts = getattr(ia, "name_parts", {}) or {}
+            if parts.get("_legacy"):
+                return parts["_legacy"].split(" ", 1)[0]
+            return parts.get("_given_name", parts.get("given_name"))
+        if attr == "family_name":
+            parts = getattr(ia, "name_parts", {}) or {}
+            if parts.get("_legacy"):
+                spl = parts["_legacy"].split(" ", 1)
+                return spl[1] if len(spl) > 1 else None
+            return parts.get("_family_name", parts.get("family_name"))
+        if attr == "street":
+            return ia.street
+        if attr == "zip":
+            return getattr(ia, "zipcode", getattr(ia, "zip", None))
+        if attr == "city":
+            return ia.city
+        if attr == "country":
+            return str(ia.country) if ia.country else None
+        if attr == "state":
+            return ia.state
+        if attr == "vat_id":
+            return ia.vat_id
+        if attr == "is_business":
+            return ia.is_business
+
+    # OrderPosition specific fields
+    if isinstance(obj, OrderPosition):
+        if key == "attendee_name":
+            return obj.attendee_name
+        if key == "attendee_given_name":
+            parts = getattr(obj, "attendee_name_parts", {}) or {}
+            if parts.get("_legacy"):
+                return parts["_legacy"].split(" ", 1)[0]
+            return parts.get("_given_name", parts.get("given_name"))
+        if key == "attendee_family_name":
+            parts = getattr(obj, "attendee_name_parts", {}) or {}
+            if parts.get("_legacy"):
+                spl = parts["_legacy"].split(" ", 1)
+                return spl[1] if len(spl) > 1 else None
+            return parts.get("_family_name", parts.get("family_name"))
+        if key == "attendee_email":
+            return obj.attendee_email
+        if key in (
+            "company",
+            "job_title",
+            "street",
+            "zipcode",
+            "city",
+            "state",
+            "price",
+            "positionid",
+            "secret",
+        ):
+            return getattr(obj, key, None)
+        if key == "country":
+            return str(obj.country) if obj.country else None
+        if key == "voucher":
+            return obj.voucher.code if obj.voucher else None
+        item = getattr(obj, "product", None) or getattr(obj, "item", None)
+        if key == "item_name":
+            return item.name if item else None
+        if key == "item_admission":
+            return item.admission if item else None
+
+        # Order fields extracted from OrderPosition
+        if key.startswith("order_"):
+            attr = key.replace("order_", "")
+            if attr == "code":
+                return obj.order.code
+            if attr == "email":
+                return obj.order.email
+            if attr == "email_domain":
+                return obj.order.email.split("@")[-1] if obj.order.email else None
+            if attr == "total":
+                return obj.order.total
+            if attr == "status":
+                return obj.order.status
+            if attr == "datetime":
+                return obj.order.datetime
+            if attr == "locale":
+                return obj.order.locale
+            if attr == "phone":
+                return obj.order.phone
+            if attr == "comment":
+                return obj.order.comment
+
+    # Order fields directly on Order
+    if isinstance(obj, Order):
+        if key == "email_domain":
+            return obj.email.split("@")[-1] if obj.email else None
+        if key == "order_link":
+            return settings.SITE_URL + reverse(
+                "presale:event.order",
+                kwargs={
+                    "organizer": obj.event.organizer.slug,
+                    "event": obj.event.slug,
+                    "order": obj.code,
+                    "secret": obj.secret,
+                },
+            )
+        # Direct attributes on Order
+        if key in (
+            "code",
+            "status",
+            "total",
+            "datetime",
+            "email",
+            "payment_datetime",
+            "locale",
+            "phone",
+            "comment",
+            "testmode",
+        ):
+            return getattr(obj, key, None)
+
+    return getattr(obj, key, None)
+
+
+def resolve_hubspot_properties(
+    obj: Any, object_mapping: ObjectTypeMapping
+) -> Dict[str, Any]:
+    """
+    Takes an eventyay object (Order or OrderPosition) and an ObjectTypeMapping,
+    and returns a dict of HubSpot property values using the field mappings.
+    """
+    content_type = ContentType.objects.get_for_model(obj)
+    field_mappings = HubSpotFieldMapping.objects.filter(
+        event=object_mapping.event,
+        content_type=content_type,
+        hubspot_object_type=object_mapping.hubspot_object_type,
+        is_active=True,
+    )
+
+    properties = {}
+    for mapping in field_mappings:
+        val = None
+        # Handle dynamic questions
+        if mapping.eventyay_field.startswith("question_"):
+            q_id = mapping.eventyay_field.replace("question_", "", 1)
+            val = _get_question_value(obj, q_id)
+        # Handle generic paths
+        else:
+            val = _resolve_eventyay_field(obj, mapping.eventyay_field)
+
+        hs_prop = HubSpotProperty.objects.filter(
+            event=object_mapping.event,
+            object_type=object_mapping.hubspot_object_type,
+            key=mapping.hubspot_property,
+        ).first()
+
+        data_type = hs_prop.data_type if hs_prop else "text"
+        val = _convert_value(val, data_type)
+        if val is not None:
+            properties[mapping.hubspot_property] = val
+
+    return properties
+
+
+def _convert_value(value: Any, data_type: str) -> Any:
+    """Convert eventyay value to matching HubSpot data type."""
+    if value is None or value == "":
+        return None
+
+    if data_type == "text":
+        return str(value)
+    elif data_type == "number":
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
+    elif data_type == "date":
+        # HubSpot expects date in specific format. Usually milliseconds since epoch or YYYY-MM-DD
+        # Let's return YYYY-MM-DD for dates or ISO 8601 for datetime
+        if hasattr(value, "isoformat"):
+            # If it's a datetime, HubSpot usually accepts ISO 8601 or date
+            return value.isoformat()
+        return str(value)
+    elif data_type == "yes/no":
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, str):
+            return "true" if value.lower() in ("true", "yes", "1", "y") else "false"
+        return "true" if value else "false"
+
+    return str(value)
+
+
+@shared_task(bind=True, max_retries=5)
+def sync_order_to_hubspot(self, order_id: int, event_id: int):
+    """
+    Main sync task that resolves fields, applies sync modes, and pushes to HubSpot.
+    """
+    try:
+        event = Event.objects.get(id=event_id)
+    except Event.DoesNotExist:
+        return
+
+    with scope(organizer=event.organizer):
+        settings = HubSpotEventSettings.objects.filter(event=event).first()
+        if not settings or not settings.sync_enabled:
+            return
+
+        if not get_valid_hubspot_token(event):
+            return
+
+        try:
+            order = Order.objects.get(id=order_id, event=event)
+        except Order.DoesNotExist:
+            return
+
+        active_mappings = ObjectTypeMapping.objects.filter(event=event)
+
+        try:
+            for object_mapping_config in active_mappings:
+                objects_to_sync = []
+                if object_mapping_config.eventyay_object_type == "order":
+                    objects_to_sync = [order]
+                elif object_mapping_config.eventyay_object_type == "order_position":
+                    objects_to_sync = list(order.positions.all())
+
+                for obj in objects_to_sync:
+                    _sync_single_object(event, object_mapping_config, obj)
+        except HubSpotTransientError as e:
+            delay = 2**self.request.retries
+            retry_after = getattr(e, "retry_after_seconds", None)
+            if retry_after:
+                delay = max(delay, retry_after)
+            raise self.retry(exc=e, countdown=delay)
+
+
+def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
+    content_type = ContentType.objects.get_for_model(obj)
+
+    # 1. Resolve raw fields using mapping
+    raw_properties = resolve_hubspot_properties(obj, config)
+
+    # 2. Apply sync mode rules
+    field_mappings = HubSpotFieldMapping.objects.filter(
+        event=event,
+        content_type=content_type,
+        hubspot_object_type=config.hubspot_object_type,
+        is_active=True,
+    )
+    mapping_modes = {fm.hubspot_property: fm.sync_mode for fm in field_mappings}
+
+    # Fetch existing tracking record if any
+    try:
+        hs_mapping = HubSpotObjectMapping.objects.get(
+            event=event,
+            content_type=content_type,
+            object_id=obj.id,
+            hubspot_object_type=config.hubspot_object_type,
+        )
+        existing_id = hs_mapping.hubspot_object_id
+    except HubSpotObjectMapping.DoesNotExist:
+        hs_mapping = None
+        existing_id = None
+
+    existing_properties = {}
+    if existing_id:
+        fill_if_empty_fields = [
+            prop
+            for prop, val in raw_properties.items()
+            if mapping_modes.get(prop) == SyncMode.FILL_IF_EMPTY
+        ]
+        if fill_if_empty_fields:
+            try:
+                existing_properties = get_record(
+                    event, config.hubspot_object_type, existing_id, fill_if_empty_fields
+                )
+            except HubSpotTransientError as e:
+                raise e
+            except HubSpotPermanentError as e:
+                # If we fail to fetch, it's safer to not overwrite anything
+                logger.warning(
+                    f"Could not fetch record {existing_id} from HubSpot: {e}"
+                )
+
+    properties_to_send = {}
+    for prop, val in raw_properties.items():
+        mode = mapping_modes.get(prop, SyncMode.OVERWRITE)
+
+        if mode == SyncMode.IDENTIFIER:
+            # Identifier is used to find/match, but also usually sent
+            properties_to_send[prop] = val
+        elif mode == SyncMode.OVERWRITE:
+            properties_to_send[prop] = val
+        elif mode == SyncMode.FILL_IF_NEW:
+            if not existing_id:
+                properties_to_send[prop] = val
+            # If existing_id is known, we skip FILL_IF_NEW
+        elif mode == SyncMode.FILL_IF_EMPTY:
+            if not existing_id:
+                properties_to_send[prop] = val
+            else:
+                existing_val = existing_properties.get(prop)
+                if existing_val is None or existing_val == "":
+                    properties_to_send[prop] = val
+
+    if not properties_to_send:
+        return
+
+    try:
+        conflict_detected = False
+        if existing_id:
+            try:
+                hubspot_id = update_record(
+                    event, config.hubspot_object_type, existing_id, properties_to_send
+                )
+                action = SyncAction.UPDATE
+            except HubSpotRecordNotFoundError:
+                try:
+                    hubspot_id = create_record(
+                        event, config.hubspot_object_type, properties_to_send
+                    )
+                    action = SyncAction.CREATE
+                except HubSpotConflictError as conflict:
+                    existing_id = conflict.existing_id
+                    action = SyncAction.UPDATE
+                    conflict_detected = True
+        else:
+            try:
+                hubspot_id = create_record(
+                    event, config.hubspot_object_type, properties_to_send
+                )
+                action = SyncAction.CREATE
+            except HubSpotConflictError as conflict:
+                existing_id = conflict.existing_id
+                action = SyncAction.UPDATE
+                conflict_detected = True
+
+        if action == SyncAction.UPDATE and conflict_detected:
+            # We must re-evaluate properties using the newly discovered existing_id to respect FILL_IF_NEW / FILL_IF_EMPTY!
+            existing_properties = {}
+            fill_if_empty_fields = [
+                prop
+                for prop, val in raw_properties.items()
+                if mapping_modes.get(prop) == SyncMode.FILL_IF_EMPTY
+            ]
+            if fill_if_empty_fields:
+                try:
+                    existing_properties = get_record(
+                        event,
+                        config.hubspot_object_type,
+                        existing_id,
+                        fill_if_empty_fields,
+                    )
+                except HubSpotTransientError as e:
+                    raise e
+                except HubSpotPermanentError as e:
+                    logger.warning(
+                        f"Could not fetch record {existing_id} from HubSpot on conflict: {e}"
+                    )
+
+            properties_to_send = {}
+            for prop, val in raw_properties.items():
+                mode = mapping_modes.get(prop, SyncMode.OVERWRITE)
+                if mode == SyncMode.IDENTIFIER:
+                    properties_to_send[prop] = val
+                elif mode == SyncMode.OVERWRITE:
+                    properties_to_send[prop] = val
+                elif mode == SyncMode.FILL_IF_NEW:
+                    # Record already exists, skip FILL_IF_NEW
+                    pass
+                elif mode == SyncMode.FILL_IF_EMPTY:
+                    existing_val = existing_properties.get(prop)
+                    if existing_val is None or existing_val == "":
+                        properties_to_send[prop] = val
+
+            if properties_to_send:
+                hubspot_id = update_record(
+                    event, config.hubspot_object_type, existing_id, properties_to_send
+                )
+            else:
+                hubspot_id = existing_id
+
+        # Update or create the tracking record
+        with transaction.atomic():
+            hs_mapping, _ = HubSpotObjectMapping.objects.update_or_create(
+                event=event,
+                content_type=content_type,
+                object_id=obj.id,
+                hubspot_object_type=config.hubspot_object_type,
+                defaults={
+                    "hubspot_object_id": hubspot_id,
+                    "last_synced_at": now(),
+                },
+            )
+            SyncLog.objects.create(
+                event=event,
+                object_mapping=hs_mapping,
+                action=action,
+                direction=SyncDirection.PUSH,
+                status=SyncStatus.SUCCESS,
+            )
+    except HubSpotTransientError as e:
+        raise e
+    except HubSpotPermanentError as e:
+        SyncLog.objects.create(
+            event=event,
+            object_mapping=hs_mapping,
+            action=SyncAction.UPDATE if existing_id else SyncAction.CREATE,
+            direction=SyncDirection.PUSH,
+            status=SyncStatus.FAILED,
+            detail={"error": str(e), "status_code": getattr(e, "status_code", None)},
+        )
+
+
+@shared_task(bind=True, max_retries=3)
+def sync_all_mappings_task(self, event_id: int):
+    """
+    Background task to enqueue sync_order_to_hubspot for all orders of an event,
+    which processes all active object/field mappings for each order.
+    """
+    with scopes_disabled():
+        order_ids = list(
+            Order.objects.filter(event_id=event_id).values_list("id", flat=True)
+        )
+
+    for order_id in order_ids:
+        sync_order_to_hubspot.apply_async(args=[order_id, event_id], countdown=0)

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -239,7 +239,11 @@ def resolve_hubspot_properties(
             key=mapping.hubspot_property,
         ).first()
 
-        data_type = hs_prop.data_type if hs_prop else "text"
+        if not hs_prop:
+            # Skip properties that don't exist in HubSpot or are read-only
+            continue
+
+        data_type = hs_prop.data_type
         val = _convert_value(val, data_type)
         if val is not None:
             properties[mapping.hubspot_property] = val
@@ -343,6 +347,8 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
             hubspot_object_type=config.hubspot_object_type,
         )
         existing_id = hs_mapping.hubspot_object_id
+        if not existing_id:
+            existing_id = None
     except HubSpotObjectMapping.DoesNotExist:
         hs_mapping = None
         existing_id = None
@@ -389,6 +395,27 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                     properties_to_send[prop] = val
 
     if not properties_to_send:
+        with transaction.atomic():
+            hs_mapping, _ = HubSpotObjectMapping.objects.update_or_create(
+                event=event,
+                content_type=content_type,
+                object_id=obj.id,
+                hubspot_object_type=config.hubspot_object_type,
+                defaults={
+                    "hubspot_object_id": existing_id or "",
+                    "last_synced_at": now(),
+                },
+            )
+            SyncLog.objects.create(
+                event=event,
+                object_mapping=hs_mapping,
+                action=SyncAction.UPDATE if existing_id else SyncAction.CREATE,
+                direction=SyncDirection.PUSH,
+                status=SyncStatus.SUCCESS,
+                detail={
+                    "message": "No properties to sync based on mappings and current values"
+                },
+            )
         return
 
     try:
@@ -463,7 +490,7 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
                     event, config.hubspot_object_type, existing_id, properties_to_send
                 )
             else:
-                hubspot_id = existing_id
+                hubspot_id = existing_id or ""
 
         # Update or create the tracking record
         with transaction.atomic():
@@ -487,6 +514,16 @@ def _sync_single_object(event: Event, config: ObjectTypeMapping, obj: Any):
     except HubSpotTransientError as e:
         raise e
     except HubSpotPermanentError as e:
+        if not hs_mapping:
+            hs_mapping, _ = HubSpotObjectMapping.objects.update_or_create(
+                event=event,
+                content_type=content_type,
+                object_id=obj.id,
+                hubspot_object_type=config.hubspot_object_type,
+                defaults={
+                    "hubspot_object_id": existing_id or "",
+                },
+            )
         SyncLog.objects.create(
             event=event,
             object_mapping=hs_mapping,

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -280,13 +280,14 @@ def _convert_value(value: Any, data_type: str) -> Any:
     return str(value)
 
 
-@shared_task(bind=True, max_retries=5)
+@shared_task(bind=True, max_retries=3)
 def sync_order_to_hubspot(self, order_id: int, event_id: int):
     """
     Main sync task that resolves fields, applies sync modes, and pushes to HubSpot.
     """
     try:
-        event = Event.objects.get(id=event_id)
+        with scopes_disabled():
+            event = Event.objects.get(id=event_id)
     except Event.DoesNotExist:
         return
 
@@ -299,7 +300,15 @@ def sync_order_to_hubspot(self, order_id: int, event_id: int):
             return
 
         try:
-            order = Order.objects.get(id=order_id, event=event)
+            order = (
+                Order.objects.select_related("invoice_address")
+                .prefetch_related(
+                    "positions__product",
+                    "positions__voucher",
+                    "positions__answers__question",
+                )
+                .get(id=order_id, event=event)
+            )
         except Order.DoesNotExist:
             return
 

--- a/hubspot/templates/hubspot/settings_landing.html
+++ b/hubspot/templates/hubspot/settings_landing.html
@@ -133,6 +133,26 @@
     </div>
 
     {% endif %}
+
+    {% if is_connected %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% translate "Sync Mapping" %}</h3>
+        </div>
+        <div class="panel-body">
+            <p>{% translate "If you have records that were created before you connected HubSpot or before you set up your object mappings, you can sync them all manually here." %}</p>
+            <p class="text-muted">
+                <i class="fa fa-info-circle"></i> {% translate "This action runs in the background and might take some time depending on the amount of data. Because of the 'Fill if new' rule, it is safe to run this multiple times." %}
+            </p>
+            <form method="post" action="{% url "plugins:hubspot:sync_mapping" organizer=request.event.organizer.slug event=request.event.slug %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-default">
+                    <i class="fa fa-refresh"></i> {% translate "Sync all mappings to HubSpot" %}
+                </button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">{% translate "Recent Activity" %}</h3>

--- a/hubspot/urls.py
+++ b/hubspot/urls.py
@@ -6,6 +6,7 @@ from hubspot.views import (
     EventHubSpotFieldMappingView,
     EventHubSpotSettingsView,
     EventHubSpotLogView,
+    EventHubSpotSyncMappingView,
 )
 
 urlpatterns = [
@@ -33,6 +34,11 @@ urlpatterns = [
         "control/event/<orgslug:organizer>/<slug:event>/hubspot/mapping/<int:mapping_id>/fields/",
         EventHubSpotFieldMappingView.as_view(),
         name="mapping_fields",
+    ),
+    path(
+        "control/event/<orgslug:organizer>/<slug:event>/hubspot/sync_mapping/",
+        EventHubSpotSyncMappingView.as_view(),
+        name="sync_mapping",
     ),
     path(
         "control/event/<orgslug:organizer>/<slug:event>/hubspot/logs/",

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -30,6 +30,7 @@ from .forms import (
 from .models import (
     AuditAction,
     AuditLog,
+    HubSpotEventSettings,
     HubSpotFieldMapping,
     HubSpotOAuthToken,
     ObjectTypeMapping,
@@ -43,6 +44,7 @@ from .models import (
 from .field_discovery import get_available_fields
 from .services import get_hubspot_properties, sync_hubspot_properties
 from .utils import get_hubspot_activity_logs
+from .tasks import sync_all_mappings_task
 
 
 def get_client_ip(request):
@@ -326,6 +328,100 @@ class EventHubSpotDisconnectView(EventPermissionRequiredMixin, View):
         return redirect(settings_url)
 
 
+class EventHubSpotLogView(EventPermissionRequiredMixin, PaginationMixin, ListView):
+    """Full activity log page for HubSpot integration."""
+
+    template_name = "hubspot/logs.html"
+    permission = "can_change_event_settings"
+    context_object_name = "activities"
+
+    def get_queryset(self):
+        form = HubSpotLogFilterForm(self.request.GET)
+        filter_type = None
+        date_from = None
+        date_to = None
+        search_query = None
+
+        if form.is_valid():
+            filter_type = form.cleaned_data.get("type")
+            date_from = form.cleaned_data.get("date_from")
+            date_to = form.cleaned_data.get("date_until")
+            search_query = form.cleaned_data.get("query")
+
+        if filter_type not in ["sync", "settings"]:
+            filter_type = None
+
+        return get_hubspot_activity_logs(
+            self.request.event,
+            filter_type=filter_type,
+            date_from=date_from,
+            date_to=date_to,
+            search_query=search_query,
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["filter_form"] = HubSpotLogFilterForm(self.request.GET)
+        return context
+
+    def post(self, request, *args, **kwargs):
+        if request.POST.get("action") == "delete":
+            if request.POST.get("select_all_pages") == "1":
+                qs = self.get_queryset()
+                if qs.search_query:
+                    # If there's a search query, we must iterate since filtering happens in Python
+                    audit_ids = []
+                    sync_ids = []
+                    for item in qs:
+                        if item["id"].startswith("audit_"):
+                            audit_ids.append(int(item["id"].split("_")[1]))
+                        elif item["id"].startswith("sync_"):
+                            sync_ids.append(int(item["id"].split("_")[1]))
+                    if audit_ids:
+                        AuditLog.objects.filter(
+                            event=request.event, id__in=audit_ids
+                        ).delete()
+                    if sync_ids:
+                        SyncLog.objects.filter(
+                            event=request.event, id__in=sync_ids
+                        ).delete()
+                else:
+                    # If no search query, we can directly delete the querysets
+                    qs.audit_logs.delete()
+                    qs.sync_logs.delete()
+            else:
+                log_ids = request.POST.getlist("log_id")
+                audit_ids = []
+                sync_ids = []
+                for log_id in log_ids:
+                    if log_id.startswith("audit_"):
+                        try:
+                            audit_ids.append(int(log_id.split("_")[1]))
+                        except (ValueError, IndexError):
+                            pass
+                    elif log_id.startswith("sync_"):
+                        try:
+                            sync_ids.append(int(log_id.split("_")[1]))
+                        except (ValueError, IndexError):
+                            pass
+
+                if audit_ids:
+                    AuditLog.objects.filter(
+                        event=request.event, id__in=audit_ids
+                    ).delete()
+                if sync_ids:
+                    SyncLog.objects.filter(
+                        event=request.event, id__in=sync_ids
+                    ).delete()
+
+            messages.success(request, _("Selected logs have been deleted."))
+            return redirect(
+                request.path_info + "?" + request.META.get("QUERY_STRING", "")
+            )
+
+        return self.get(request, *args, **kwargs)
+
+
 class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
     """View to manage field mapping rows for a specific object mapping type."""
 
@@ -501,100 +597,49 @@ class EventHubSpotFieldMappingView(EventPermissionRequiredMixin, TemplateView):
                 )
             )
         else:
+            messages.error(
+                request,
+                _(
+                    "There were errors saving your configuration. Please check the form."
+                ),
+            )
             return self.render_to_response(
                 self.get_context_data(setup=setup, formset=formset)
             )
 
 
-class EventHubSpotLogView(EventPermissionRequiredMixin, PaginationMixin, ListView):
-    """Full activity log page for HubSpot integration."""
+class EventHubSpotSyncMappingView(EventPermissionRequiredMixin, View):
+    """Triggers background sync for all mappings of the event."""
 
-    template_name = "hubspot/logs.html"
     permission = "can_change_event_settings"
-    context_object_name = "activities"
-
-    def get_queryset(self):
-        form = HubSpotLogFilterForm(self.request.GET)
-        filter_type = None
-        date_from = None
-        date_to = None
-        search_query = None
-
-        if form.is_valid():
-            filter_type = form.cleaned_data.get("type")
-            date_from = form.cleaned_data.get("date_from")
-            date_to = form.cleaned_data.get("date_until")
-            search_query = form.cleaned_data.get("query")
-
-        if filter_type not in ["sync", "settings"]:
-            filter_type = None
-
-        return get_hubspot_activity_logs(
-            self.request.event,
-            filter_type=filter_type,
-            date_from=date_from,
-            date_to=date_to,
-            search_query=search_query,
-        )
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["filter_form"] = HubSpotLogFilterForm(self.request.GET)
-        return context
 
     def post(self, request, *args, **kwargs):
-        if request.POST.get("action") == "delete":
-            if request.POST.get("select_all_pages") == "1":
-                qs = self.get_queryset()
-                if qs.search_query:
-                    # If there's a search query, we must iterate since filtering happens in Python
-                    audit_ids = []
-                    sync_ids = []
-                    for item in qs:
-                        if item["id"].startswith("audit_"):
-                            audit_ids.append(int(item["id"].split("_")[1]))
-                        elif item["id"].startswith("sync_"):
-                            sync_ids.append(int(item["id"].split("_")[1]))
-                    if audit_ids:
-                        AuditLog.objects.filter(
-                            event=request.event, id__in=audit_ids
-                        ).delete()
-                    if sync_ids:
-                        SyncLog.objects.filter(
-                            event=request.event, id__in=sync_ids
-                        ).delete()
-                else:
-                    # If no search query, we can directly delete the querysets
-                    qs.audit_logs.delete()
-                    qs.sync_logs.delete()
-            else:
-                log_ids = request.POST.getlist("log_id")
-                audit_ids = []
-                sync_ids = []
-                for log_id in log_ids:
-                    if log_id.startswith("audit_"):
-                        try:
-                            audit_ids.append(int(log_id.split("_")[1]))
-                        except (ValueError, IndexError):
-                            pass
-                    elif log_id.startswith("sync_"):
-                        try:
-                            sync_ids.append(int(log_id.split("_")[1]))
-                        except (ValueError, IndexError):
-                            pass
+        settings_url = reverse(
+            "plugins:hubspot:hubspot",
+            kwargs={
+                "organizer": request.event.organizer.slug,
+                "event": request.event.slug,
+            },
+        )
 
-                if audit_ids:
-                    AuditLog.objects.filter(
-                        event=request.event, id__in=audit_ids
-                    ).delete()
-                if sync_ids:
-                    SyncLog.objects.filter(
-                        event=request.event, id__in=sync_ids
-                    ).delete()
+        try:
+            token = HubSpotOAuthToken.objects.get(event=request.event)
+            token.check()  # Ensure token is valid and refresh if needed
+        except HubSpotOAuthToken.DoesNotExist:
+            messages.error(request, _("Not connected to HubSpot."))
+            return redirect(settings_url)
 
-            messages.success(request, _("Selected logs have been deleted."))
-            return redirect(
-                request.path_info + "?" + request.META.get("QUERY_STRING", "")
-            )
+        settings = HubSpotEventSettings.objects.filter(event=request.event).first()
+        if not settings or not settings.sync_enabled:
+            messages.error(request, _("Sync is disabled for this event."))
+            return redirect(settings_url)
 
-        return self.get(request, *args, **kwargs)
+        sync_all_mappings_task.apply_async(args=[request.event.id])
+
+        messages.success(
+            request,
+            _(
+                "Mapping sync started in the background. Depending on the amount of data, this may take a few minutes."
+            ),
+        )
+        return redirect(settings_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from eventyay.base.models import Event, Organizer, Team, User
+from eventyay.base.models import Event, Organizer, Team, User, Order
 from django.utils.timezone import now
 from datetime import timedelta
 
@@ -45,3 +45,15 @@ def logged_in_organizer_client(client, user, organizer, event):
     team.members.add(user)
     client.force_login(user)
     return client
+
+
+@pytest.fixture
+def order(event):
+    return Order.objects.create(
+        event=event,
+        code="TEST1",
+        status="n",
+        email="dummy@dummy.dummy",
+        total=10.00,
+        locale="en",
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,8 +79,7 @@ def test_update_record_no_token(event, caplog):
 
 @pytest.mark.django_db
 @mock.patch("hubspot.client.requests.post")
-@mock.patch("hubspot.client.requests.patch")
-def test_create_409_falls_back_to_update(mock_patch, mock_post, event, hubspot_token):
+def test_create_409_raises_conflict(mock_post, event, hubspot_token):
     mock_post_response = mock.Mock()
     mock_post_response.ok = False
     mock_post_response.status_code = 409
@@ -89,19 +88,14 @@ def test_create_409_falls_back_to_update(mock_patch, mock_post, event, hubspot_t
     }
     mock_post.return_value = mock_post_response
 
-    mock_patch_response = mock.Mock()
-    mock_patch_response.ok = True
-    mock_patch_response.status_code = 200
-    mock_patch.return_value = mock_patch_response
+    from hubspot.client import HubSpotConflictError
 
-    record_id = create_record(event, "contact", {"firstname": "John"})
+    with pytest.raises(HubSpotConflictError) as exc_info:
+        create_record(event, "contact", {"firstname": "John"})
 
-    assert record_id == "98765"
+    assert exc_info.value.existing_id == "98765"
+    assert exc_info.value.status_code == 409
     mock_post.assert_called_once()
-    mock_patch.assert_called_once()
-
-    args, kwargs = mock_patch.call_args
-    assert "/crm/v3/objects/contacts/98765" in args[0]
 
 
 @pytest.mark.django_db

--- a/tests/test_field_discovery.py
+++ b/tests/test_field_discovery.py
@@ -1,6 +1,7 @@
 import pytest
 from eventyay.base.models import Question
 
+from django_scopes import scope
 from hubspot.field_discovery import get_available_fields
 
 
@@ -62,8 +63,6 @@ def test_get_available_fields_order_position_no_event():
 @pytest.mark.django_db
 def test_get_available_fields_order_position_empty_event(event):
     # Event without any questions defined
-    from django_scopes import scope
-
     with scope(organizer=event.organizer):
         fields = get_available_fields("order_position", event=event)
 
@@ -75,8 +74,6 @@ def test_get_available_fields_order_position_empty_event(event):
 
 @pytest.mark.django_db
 def test_get_available_fields_order_position_with_event(event):
-    from django_scopes import scope
-
     with scope(organizer=event.organizer):
         # Create some questions for the event
         Question.objects.create(

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -10,6 +10,9 @@ from django_scopes import scopes_disabled
 @pytest.fixture(autouse=True)
 def disable_scopes():
     with scopes_disabled():
+        from django.core.cache import cache
+
+        cache.clear()
         yield
 
 
@@ -28,7 +31,9 @@ def test_enqueue_sync_skipped_if_disabled(mock_apply, event, order):
 
 @pytest.mark.django_db
 @mock.patch("hubspot.signals.sync_order_to_hubspot.apply_async")
-def test_enqueue_sync_success(mock_apply, event, order):
+def test_enqueue_sync_success(
+    mock_apply, event, order, django_capture_on_commit_callbacks
+):
     HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
     from hubspot.models import HubSpotOAuthToken
 
@@ -38,5 +43,7 @@ def test_enqueue_sync_success(mock_apply, event, order):
         refresh_token="valid_refresh",
         expires_at=now() + datetime.timedelta(hours=1),
     )
-    _enqueue_hubspot_sync(None, order)
+    order.status = "p"
+    with django_capture_on_commit_callbacks(execute=True):
+        _enqueue_hubspot_sync(None, order)
     mock_apply.assert_called_once_with(args=[order.id, event.id], countdown=5)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,42 @@
+import datetime
+from django.utils.timezone import now
+import pytest
+from unittest import mock
+from hubspot.models import HubSpotEventSettings
+from hubspot.signals import _enqueue_hubspot_sync
+from django_scopes import scopes_disabled
+
+
+@pytest.fixture(autouse=True)
+def disable_scopes():
+    with scopes_disabled():
+        yield
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.signals.sync_order_to_hubspot.apply_async")
+def test_enqueue_sync_skipped_if_disabled(mock_apply, event, order):
+    # No settings
+    _enqueue_hubspot_sync(None, order)
+    mock_apply.assert_not_called()
+
+    # Disabled
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=False)
+    _enqueue_hubspot_sync(None, order)
+    mock_apply.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.signals.sync_order_to_hubspot.apply_async")
+def test_enqueue_sync_success(mock_apply, event, order):
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
+    from hubspot.models import HubSpotOAuthToken
+
+    HubSpotOAuthToken.objects.create(
+        event=event,
+        access_token="valid_access",
+        refresh_token="valid_refresh",
+        expires_at=now() + datetime.timedelta(hours=1),
+    )
+    _enqueue_hubspot_sync(None, order)
+    mock_apply.assert_called_once_with(args=[order.id, event.id], countdown=5)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,280 @@
+import pytest
+from unittest import mock
+from django.contrib.contenttypes.models import ContentType
+from eventyay.base.models import InvoiceAddress
+from hubspot.models import (
+    HubSpotEventSettings,
+    HubSpotFieldMapping,
+    HubSpotObjectMapping,
+    HubSpotProperty,
+    ObjectTypeMapping,
+    SyncLog,
+    SyncMode,
+    SyncStatus,
+)
+from hubspot.tasks import (
+    _convert_value,
+    sync_order_to_hubspot,
+)
+from hubspot.client import HubSpotTransientError, HubSpotPermanentError
+from django_scopes import scopes_disabled
+from celery.exceptions import Retry
+
+
+@pytest.fixture(autouse=True)
+def disable_scopes():
+    with scopes_disabled():
+        yield
+
+
+def test_convert_value():
+    assert _convert_value(None, "text") is None
+    assert _convert_value("", "text") is None
+    assert _convert_value(123, "text") == "123"
+
+    assert _convert_value("123.45", "number") == 123.45
+    assert _convert_value("abc", "number") is None
+
+    assert _convert_value(True, "yes/no") == "true"
+    assert _convert_value(False, "yes/no") == "false"
+    assert _convert_value("Yes", "yes/no") == "true"
+    assert _convert_value("N", "yes/no") == "false"
+
+
+@pytest.fixture
+def mock_event(event):
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
+    from hubspot.models import HubSpotOAuthToken
+    from django.utils.timezone import now
+    import datetime
+
+    HubSpotOAuthToken.objects.create(
+        event=event,
+        access_token="valid_access",
+        refresh_token="valid_refresh",
+        expires_at=now() + datetime.timedelta(hours=1),
+    )
+    return event
+
+
+@pytest.fixture
+def object_mapping(mock_event):
+    return ObjectTypeMapping.objects.create(
+        event=mock_event, eventyay_object_type="order", hubspot_object_type="contacts"
+    )
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.tasks.create_record")
+def test_sync_skipped_when_disabled(mock_create, mock_event, object_mapping, order):
+    settings = HubSpotEventSettings.objects.get(event=mock_event)
+    settings.sync_enabled = False
+    settings.save()
+
+    sync_order_to_hubspot(order.id, mock_event.id)
+
+    mock_create.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.tasks.create_record")
+def test_sync_order_success(mock_create, mock_event, object_mapping, order):
+    mock_create.return_value = "hub_123"
+
+    ct = ContentType.objects.get_for_model(order)
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="email",
+        hubspot_object_type="contacts",
+        hubspot_property="email",
+        sync_mode=SyncMode.IDENTIFIER,
+    )
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="email",
+        data_type="text",
+        sync_batch="00000000-0000-0000-0000-000000000000",
+    )
+
+    sync_order_to_hubspot(order.id, mock_event.id)
+
+    mock_create.assert_called_once()
+    assert mock_create.call_args[0][2] == {"email": order.email}
+
+    # Verify SyncRecord created
+    mapping = HubSpotObjectMapping.objects.get(event=mock_event, object_id=order.id)
+    assert mapping.hubspot_object_id == "hub_123"
+
+    log = SyncLog.objects.get(event=mock_event, object_mapping=mapping)
+    assert log.status == SyncStatus.SUCCESS
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.tasks.get_record")
+@mock.patch("hubspot.tasks.update_record")
+def test_sync_modes(mock_update, mock_get_record, mock_event, object_mapping, order):
+    mock_update.return_value = "hub_123"
+    mock_get_record.return_value = {"company": "OldCompany", "phone": ""}
+
+    ct = ContentType.objects.get_for_model(order)
+
+    # Existing mapping
+    HubSpotObjectMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        object_id=order.id,
+        hubspot_object_type="contacts",
+        hubspot_object_id="hub_123",
+    )
+
+    # Add field mappings
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="email",
+        hubspot_object_type="contacts",
+        hubspot_property="email",
+        sync_mode=SyncMode.IDENTIFIER,
+    )
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="total",
+        hubspot_object_type="contacts",
+        hubspot_property="amount",
+        sync_mode=SyncMode.OVERWRITE,
+    )
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="locale",
+        hubspot_object_type="contacts",
+        hubspot_property="locale",
+        sync_mode=SyncMode.FILL_IF_NEW,
+    )
+
+    # Mocking order values
+    order.email = "test@example.com"
+    order.total = 100.0
+    order.locale = "en"
+    order.save()
+
+    sync_order_to_hubspot(order.id, mock_event.id)
+
+    mock_update.assert_called_once()
+    properties_sent = mock_update.call_args[0][3]
+
+    assert "email" in properties_sent
+    assert "amount" in properties_sent
+    assert (
+        "locale" not in properties_sent
+    )  # Skipped because Fill if New and record exists
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.tasks.get_record")
+@mock.patch("hubspot.tasks.update_record")
+def test_sync_fill_if_empty(
+    mock_update, mock_get_record, mock_event, object_mapping, order
+):
+    mock_update.return_value = "hub_123"
+    mock_get_record.return_value = {"phone": "", "company": "ExistingCorp"}
+
+    ct = ContentType.objects.get_for_model(order)
+    HubSpotObjectMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        object_id=order.id,
+        hubspot_object_type="contacts",
+        hubspot_object_id="hub_123",
+    )
+
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="phone",
+        hubspot_object_type="contacts",
+        hubspot_property="phone",
+        sync_mode=SyncMode.FILL_IF_EMPTY,
+    )
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="invoice_company",
+        hubspot_object_type="contacts",
+        hubspot_property="company",
+        sync_mode=SyncMode.FILL_IF_EMPTY,
+    )
+
+    order.phone = "12345"
+    order.save()
+
+    InvoiceAddress.objects.create(order=order, company="NewCorp")
+
+    # Wait, we need to save the order or mock it properly since `invoice_address` is a related model in Eventyay.
+    # Eventyay order.invoice_address is a relation. Let's create an invoice address if needed or just use another field.
+    # To be safe, we'll map event_name instead.
+
+    HubSpotFieldMapping.objects.filter(hubspot_property="company").update(
+        eventyay_field="event_name"
+    )
+    order.event.name = "NewEvent"
+    order.event.save()
+
+    sync_order_to_hubspot(order.id, mock_event.id)
+
+    properties_sent = mock_update.call_args[0][3]
+    assert "phone" in properties_sent  # Was empty, so sent
+    assert properties_sent["phone"] == "12345"
+    assert "company" not in properties_sent  # Was not empty, so skipped
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.tasks.create_record")
+@mock.patch("hubspot.tasks.sync_order_to_hubspot.retry")
+def test_transient_error_retries(
+    mock_retry, mock_create, mock_event, object_mapping, order
+):
+    mock_retry.side_effect = Retry()
+    mock_create.side_effect = HubSpotTransientError("Timeout", retry_after_seconds=10)
+
+    ct = ContentType.objects.get_for_model(order)
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="email",
+        hubspot_object_type="contacts",
+        hubspot_property="email",
+        sync_mode=SyncMode.IDENTIFIER,
+    )
+
+    with pytest.raises(Retry):
+        sync_order_to_hubspot(order.id, mock_event.id)
+
+    mock_retry.assert_called_once()
+    assert mock_retry.call_args[1]["countdown"] == 10
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.tasks.create_record")
+def test_permanent_error_no_retry(mock_create, mock_event, object_mapping, order):
+    mock_create.side_effect = HubSpotPermanentError("Invalid data", status_code=400)
+
+    ct = ContentType.objects.get_for_model(order)
+    HubSpotFieldMapping.objects.create(
+        event=mock_event,
+        content_type=ct,
+        eventyay_field="email",
+        hubspot_object_type="contacts",
+        hubspot_property="email",
+        sync_mode=SyncMode.IDENTIFIER,
+    )
+
+    # Should not raise Retry, but should silently record failure
+    sync_order_to_hubspot(order.id, mock_event.id)
+
+    logs = SyncLog.objects.filter(event=mock_event)
+    assert logs.count() == 1
+    assert logs.first().status == SyncStatus.FAILED

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 from unittest import mock
 from django.contrib.contenttypes.models import ContentType
 from eventyay.base.models import InvoiceAddress
@@ -130,6 +131,29 @@ def test_sync_modes(mock_update, mock_get_record, mock_event, object_mapping, or
     )
 
     # Add field mappings
+    dummy_batch = uuid.uuid4()
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="email",
+        data_type="text",
+        sync_batch=dummy_batch,
+    )
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="amount",
+        data_type="number",
+        sync_batch=dummy_batch,
+    )
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="locale",
+        data_type="text",
+        sync_batch=dummy_batch,
+    )
+
     HubSpotFieldMapping.objects.create(
         event=mock_event,
         content_type=ct,
@@ -191,6 +215,22 @@ def test_sync_fill_if_empty(
         hubspot_object_id="hub_123",
     )
 
+    dummy_batch = uuid.uuid4()
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="phone",
+        data_type="text",
+        sync_batch=dummy_batch,
+    )
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="company",
+        data_type="text",
+        sync_batch=dummy_batch,
+    )
+
     HubSpotFieldMapping.objects.create(
         event=mock_event,
         content_type=ct,
@@ -241,6 +281,15 @@ def test_transient_error_retries(
     mock_create.side_effect = HubSpotTransientError("Timeout", retry_after_seconds=10)
 
     ct = ContentType.objects.get_for_model(order)
+
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="email",
+        data_type="text",
+        sync_batch=uuid.uuid4(),
+    )
+
     HubSpotFieldMapping.objects.create(
         event=mock_event,
         content_type=ct,
@@ -263,6 +312,15 @@ def test_permanent_error_no_retry(mock_create, mock_event, object_mapping, order
     mock_create.side_effect = HubSpotPermanentError("Invalid data", status_code=400)
 
     ct = ContentType.objects.get_for_model(order)
+
+    HubSpotProperty.objects.create(
+        event=mock_event,
+        object_type="contacts",
+        key="email",
+        data_type="text",
+        sync_batch=uuid.uuid4(),
+    )
+
     HubSpotFieldMapping.objects.create(
         event=mock_event,
         content_type=ct,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,7 +2,9 @@ import pytest
 from django.urls import reverse
 from unittest import mock
 from django_scopes import scope
-from hubspot.models import HubSpotOAuthToken
+from hubspot.models import HubSpotOAuthToken, HubSpotProperty, HubSpotPropertySyncState
+import uuid
+import requests
 
 
 @pytest.mark.django_db
@@ -75,9 +77,6 @@ def test_hubspot_disconnect_view_connected(
     mock_response.ok = True
     mock_delete.return_value = mock_response
 
-    from hubspot.models import HubSpotProperty, HubSpotPropertySyncState
-    import uuid
-
     with scope(organizer=event.organizer):
         batch = uuid.uuid4()
         HubSpotProperty.objects.create(
@@ -117,7 +116,6 @@ def test_hubspot_disconnect_view_revoke_failure_still_clears(
         )
 
     # Simulate a network error or 500 from HubSpot
-    import requests
 
     mock_delete.side_effect = requests.RequestException("Timeout")
 


### PR DESCRIPTION
Closes #26
Closes #27 

> [!NOTE]
> This PR is stacked upon the following PRs and will be ready for review once they are merged
> - #29 
> - #31 
> - #38
> 
> | [View Diff for this branch](https://github.com/ViRUS-0-0/eventyay-hubspot/compare/main...ViRUS-0-0:i-26) |
> | :--- |
 

- With the client https://github.com/fossasia/eventyay-hubspot/issues/25 able to talk to HubSpot and the mapping configuration (Phase 3) describing what to send, this pr adds the task that actually resolves an order or order position into HubSpot properties and pushes them, respecting each field's sync mode.
- This pr also connects eventyay's order lifecycle to the sync task, without touching eventyay core. No HubSpot call should ever happen inside the request/response cycle — everything is queued.

 
 ## Screenshots & Videos

https://github.com/user-attachments/assets/7fe5c927-fc18-41e2-97b5-1efd787d1894

---

https://github.com/user-attachments/assets/e665e37a-75a2-4afa-9d7e-7bcb19acb7de

---

<img width="1456" height="701" alt="Screenshot 2026-07-03 at 5 28 46 PM" src="https://github.com/user-attachments/assets/66f558ee-685d-423f-912e-f6ee96fc17ab" />

