### PR TITLE
Replace flake8, isort, and black with Ruff for Python linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,7 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.5
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -23,13 +23,24 @@ This is a plugin for [Eventyay](https://github.com/fossasia/eventyay) that enabl
 
 ## Code Style & Linting
 
-This repository enforces code style guidelines via CI. You can run checks locally by installing the development dependencies:
+This repository uses [Ruff](https://docs.astral.sh/ruff/) for Python linting, import sorting, and formatting.
+
+You can run checks locally:
 
 ```bash
-pip install pre-commit ruff black
+pip install pre-commit ruff
 pre-commit install
 
 pre-commit run --all-files
+```
+
+To run Ruff directly:
+
+```bash
+ruff check .
+ruff check . --fix
+ruff format .
+ruff format --check .
 ```
 
 ## License

--- a/hubspot/admin.py
+++ b/hubspot/admin.py
@@ -4,8 +4,8 @@ from .models import (
     AuditLog,
     HubSpotEventSettings,
     HubSpotFieldMapping,
-    HubSpotObjectMapping,
     HubSpotOAuthToken,
+    HubSpotObjectMapping,
     ObjectTypeMapping,
     SyncLog,
 )

--- a/hubspot/apps.py
+++ b/hubspot/apps.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-from django.utils.translation import gettext_lazy as _
+
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import gettext_lazy as _
 from dotenv import load_dotenv
 
 from . import __version__
-
 
 try:
     from eventyay.base.plugins import PluginConfig

--- a/hubspot/client.py
+++ b/hubspot/client.py
@@ -1,5 +1,6 @@
 import logging
 import re
+
 import requests
 
 from .services import get_valid_hubspot_token

--- a/hubspot/forms.py
+++ b/hubspot/forms.py
@@ -1,10 +1,10 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from eventyay.base.forms.widgets import DatePickerWidget
 from eventyay.base.models import Event
 from eventyay.control.forms.filter import FilterForm
-from eventyay.base.forms.widgets import DatePickerWidget
 
-from .models import ObjectTypeMapping, HubSpotFieldMapping, SyncMode
+from .models import HubSpotFieldMapping, ObjectTypeMapping, SyncMode
 
 
 class HubSpotLogFilterForm(FilterForm):
@@ -221,9 +221,9 @@ class BaseHubSpotFieldMappingFormSet(forms.BaseModelFormSet):
                 (SyncMode.IDENTIFIER, _("Identifier"))
             ]
             form.fields["sync_mode"].widget.attrs["readonly"] = True
-            form.fields["sync_mode"].widget.attrs[
-                "style"
-            ] = "pointer-events: none; background-color: #eee;"
+            form.fields["sync_mode"].widget.attrs["style"] = (
+                "pointer-events: none; background-color: #eee;"
+            )
             if not form.initial.get("sync_mode"):
                 form.initial["sync_mode"] = SyncMode.IDENTIFIER
         else:

--- a/hubspot/migrations/0001_initial.py
+++ b/hubspot/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/hubspot/migrations/0002_hubspotoauthtoken_hub_name_auditlog.py
+++ b/hubspot/migrations/0002_hubspotoauthtoken_hub_name_auditlog.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("base", "0030_room_is_unscheduled_team_polls_questions"),
         ("hubspot", "0001_initial"),

--- a/hubspot/migrations/0003_objecttypemapping.py
+++ b/hubspot/migrations/0003_objecttypemapping.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("base", "0030_room_is_unscheduled_team_polls_questions"),
         ("hubspot", "0002_hubspotoauthtoken_hub_name_auditlog"),

--- a/hubspot/migrations/0004_hubspotproperty_hubspotpropertysyncstate.py
+++ b/hubspot/migrations/0004_hubspotproperty_hubspotpropertysyncstate.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("base", "0031_migrate_meta_noindex"),
         ("hubspot", "0003_objecttypemapping"),

--- a/hubspot/migrations/0005_hubspotfieldmapping_sync_mode.py
+++ b/hubspot/migrations/0005_hubspotfieldmapping_sync_mode.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hubspot", "0004_hubspotproperty_hubspotpropertysyncstate"),
     ]

--- a/hubspot/models.py
+++ b/hubspot/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models import JSONField
 from django.utils.translation import gettext_lazy as _
 from django_scopes import ScopedManager
+
 from .utils import decrypt, encrypt
 
 

--- a/hubspot/services.py
+++ b/hubspot/services.py
@@ -1,7 +1,8 @@
 import datetime
+import logging
 import os
 import uuid
-import logging
+
 import requests
 from django.db import transaction
 from django.utils.timezone import now

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -1,20 +1,22 @@
+from datetime import timedelta
+
+from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.urls import resolve, reverse
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-from django.contrib.contenttypes.models import ContentType
 from eventyay.base.models import Order, OrderPosition
 from eventyay.base.signals import periodic_task
 from eventyay.control.signals import nav_event
+
 from .models import (
-    ObjectTypeMapping,
+    AuditLog,
     HubSpotFieldMapping,
     HubSpotObjectMapping,
-    AuditLog,
+    ObjectTypeMapping,
     SyncLog,
 )
-from django.utils.timezone import now
-from datetime import timedelta
 
 
 @receiver(nav_event, dispatch_uid="hubspot_nav")

--- a/hubspot/urls.py
+++ b/hubspot/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
+
 from hubspot.views import (
     EventHubSpotCallbackView,
     EventHubSpotConnectView,
     EventHubSpotDisconnectView,
     EventHubSpotFieldMappingView,
-    EventHubSpotSettingsView,
     EventHubSpotLogView,
+    EventHubSpotSettingsView,
 )
 
 urlpatterns = [

--- a/hubspot/utils.py
+++ b/hubspot/utils.py
@@ -1,12 +1,12 @@
 import base64
 import hashlib
+from datetime import datetime, time
 from functools import lru_cache
 
 from cryptography.fernet import Fernet
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import make_aware
-from datetime import datetime, time
+from django.utils.translation import gettext_lazy as _
 
 
 @lru_cache(maxsize=1)

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -6,25 +6,24 @@ import urllib.parse
 
 import requests
 from django.contrib import messages
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
+from django.forms import modelformset_factory
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.core.exceptions import PermissionDenied
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, TemplateView, View
 from django_scopes import scope
 from eventyay.base.models import Event, Order, OrderPosition
-
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views import PaginationMixin
 
-from django.contrib.contenttypes.models import ContentType
-from django.forms import modelformset_factory
-
+from .field_discovery import get_available_fields
 from .forms import (
-    HubSpotLogFilterForm,
     BaseHubSpotFieldMappingFormSet,
     HubSpotFieldMappingForm,
+    HubSpotLogFilterForm,
     ObjectTypeMappingFormSet,
 )
 from .models import (
@@ -32,15 +31,14 @@ from .models import (
     AuditLog,
     HubSpotFieldMapping,
     HubSpotOAuthToken,
-    ObjectTypeMapping,
     HubSpotProperty,
     HubSpotPropertySyncState,
+    ObjectTypeMapping,
     SyncAction,
     SyncDirection,
     SyncLog,
     SyncStatus,
 )
-from .field_discovery import get_available_fields
 from .services import get_hubspot_properties, sync_hubspot_properties
 from .utils import get_hubspot_activity_logs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,20 @@ namespaces = false
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "eventyay.config.settings"
 
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "W"]
+ignore = ["B904", "E501"]
+unfixable = ["B"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+
 [tool.coverage.run]
 source = ["hubspot"]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "W"]
 ignore = ["B904", "E501"]
-unfixable = ["B"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
-import pytest
-from eventyay.base.models import Event, Organizer, Team, User
-from django.utils.timezone import now
 from datetime import timedelta
+
+import pytest
+from django.utils.timezone import now
+from eventyay.base.models import Event, Organizer, Team, User
 
 
 @pytest.fixture

--- a/tests/test_audit_log_ui.py
+++ b/tests/test_audit_log_ui.py
@@ -3,14 +3,15 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django_scopes import scope
 from eventyay.base.models import Event
+
 from hubspot.models import (
-    AuditLog,
-    SyncLog,
     AuditAction,
+    AuditLog,
+    HubSpotObjectMapping,
     SyncAction,
     SyncDirection,
+    SyncLog,
     SyncStatus,
-    HubSpotObjectMapping,
 )
 
 
@@ -54,7 +55,6 @@ def test_hubspot_logs_view_all_entries(
     settings.SITE_URL = "https://testserver"
 
     with scope(organizer=event.organizer):
-
         AuditLog.objects.create(
             organizer=event.organizer,
             event=event,
@@ -175,8 +175,9 @@ def test_hubspot_logs_view_permission_denied(
 def test_hubspot_logs_view_order_and_position_synced_formatting(
     logged_in_organizer_client, organizer, event, settings
 ):
-    from django.utils.timezone import now
     from datetime import timedelta
+
+    from django.utils.timezone import now
     from eventyay.base.models import Order, OrderPosition, Product
 
     settings.SITE_URL = "https://testserver"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,8 +10,8 @@ from hubspot.client import (
     HubSpotPermanentError,
     HubSpotTransientError,
     create_record,
-    update_record,
     get_record,
+    update_record,
 )
 from hubspot.models import HubSpotOAuthToken
 

--- a/tests/test_field_mapping.py
+++ b/tests/test_field_mapping.py
@@ -1,11 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-
+from django_scopes import scope, scopes_disabled
 from eventyay.base.models import Order
-from hubspot.models import HubSpotFieldMapping, SyncMode, ObjectTypeMapping
-from django_scopes import scopes_disabled, scope
-from unittest.mock import patch
+
+from hubspot.models import HubSpotFieldMapping, ObjectTypeMapping, SyncMode
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import pytest
-from django.db import IntegrityError, transaction
-
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError, transaction
 
 from hubspot.models import (
     HubSpotEventSettings,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2,10 +2,9 @@ import pytest
 import responses
 from django.contrib.messages import get_messages
 from django.urls import reverse
-
 from django_scopes import scope
 
-from hubspot.models import HubSpotOAuthToken, SyncLog, SyncAction
+from hubspot.models import HubSpotOAuthToken, SyncAction, SyncLog
 
 
 @pytest.mark.django_db

--- a/tests/test_object_mappings.py
+++ b/tests/test_object_mappings.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from django_scopes import scope
 
-from hubspot.models import ObjectTypeMapping, HubSpotOAuthToken
+from hubspot.models import HubSpotOAuthToken, ObjectTypeMapping
 
 
 def _settings_url(organizer, event):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,9 +1,9 @@
 import datetime
 import uuid
-import requests
 from unittest import mock
 
 import pytest
+import requests
 from django.utils.timezone import now
 from django_scopes import scope
 
@@ -13,9 +13,9 @@ from hubspot.models import (
     HubSpotPropertySyncState,
 )
 from hubspot.services import (
-    get_valid_hubspot_token,
-    get_hubspot_properties,
     HubSpotFetchError,
+    get_hubspot_properties,
+    get_valid_hubspot_token,
 )
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,6 +1,7 @@
 import pytest
 from django.urls import reverse
 from django_scopes import scope
+
 from hubspot.models import HubSpotOAuthToken
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,9 @@
+from unittest import mock
+
 import pytest
 from django.urls import reverse
-from unittest import mock
 from django_scopes import scope
+
 from hubspot.models import HubSpotOAuthToken
 
 
@@ -75,8 +77,9 @@ def test_hubspot_disconnect_view_connected(
     mock_response.ok = True
     mock_delete.return_value = mock_response
 
-    from hubspot.models import HubSpotProperty, HubSpotPropertySyncState
     import uuid
+
+    from hubspot.models import HubSpotProperty, HubSpotPropertySyncState
 
     with scope(organizer=event.organizer):
         batch = uuid.uuid4()


### PR DESCRIPTION
Closes #24

Replaces flake8, isort, and black with Ruff across the repository.

### Changes
- **pyproject.toml**: Added Ruff configuration (line-length=88, target-version=py311, lint rules E/F/I/B/UP/W)
- **.pre-commit-config.yaml**: Removed black hook, replaced with ruff-format; updated ruff-pre-commit rev
- **README.md**: Updated code style & linting section with Ruff commands
- **All Python files**: Autofixed import sorting (I001) via `ruff check --fix`, formatted via `ruff format`

### Verification
- `ruff check .` — all checks pass
- `ruff format --check .` — all files already formatted

### Acceptance criteria
- [x] Ruff added as primary linting and formatting tool
- [x] Import sorting handled by Ruff (replaces isort)
- [x] Formatting handled by ruff-format (replaces black)
- [x] Pre-commit updated with ruff + ruff-format hooks
- [x] Documentation updated with ruff commands
- [x] No functional changes — only tooling config + formatting

## Summary by Sourcery

Adopt Ruff as the unified Python linting, import-sorting, and formatting tool across the project, updating configuration, tooling, and docs accordingly.

New Features:
- Introduce Ruff configuration in pyproject.toml for linting and formatting.

Enhancements:
- Normalize imports, spacing, and minor style across Python modules and tests using Ruff auto-fixes.

Build:
- Update pre-commit configuration to remove Black and add Ruff and ruff-format hooks.

Documentation:
- Revise README code style and linting instructions to reference Ruff commands instead of Black.