### PR TITLE
feat: per-order hubspot sync status on order detail page

### DIFF
--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -166,14 +166,37 @@ def control_order_info(sender, request, order, **kwargs):
     last_synced_at = None
     sync_needed = True
 
-    content_type = ContentType.objects.get_for_model(Order)
-    mapping = HubSpotObjectMapping.objects.filter(
-        event=order.event, content_type=content_type, object_id=order.id
+    content_type_order = ContentType.objects.get_for_model(Order)
+    content_type_position = ContentType.objects.get_for_model(OrderPosition)
+
+    order_mapping = HubSpotObjectMapping.objects.filter(
+        event=order.event, content_type=content_type_order, object_id=order.id
     ).first()
 
-    if mapping:
-        last_synced_at = mapping.last_synced_at
-        latest_log = mapping.synclog_set.order_by("-created_at").first()
+    position_ids = order.positions.values_list("id", flat=True)
+    position_mappings = HubSpotObjectMapping.objects.filter(
+        event=order.event,
+        content_type=content_type_position,
+        object_id__in=position_ids,
+    )
+
+    mappings = []
+    if order_mapping:
+        mappings.append(order_mapping)
+    mappings.extend(position_mappings)
+
+    if mappings:
+        mapping_ids = [m.id for m in mappings]
+        latest_log = (
+            SyncLog.objects.filter(object_mapping_id__in=mapping_ids)
+            .order_by("-created_at")
+            .first()
+        )
+        last_synced_at = max(
+            (m.last_synced_at for m in mappings if m.last_synced_at is not None),
+            default=None,
+        )
+
         if latest_log:
             if latest_log.status == SyncStatus.SUCCESS:
                 status_text = "Synced"
@@ -203,14 +226,17 @@ def control_order_info(sender, request, order, **kwargs):
 
     has_mapping_changes = False
     if status_text == "Synced":
-        object_type_mapping = ObjectTypeMapping.objects.filter(
-            event=order.event, eventyay_object_type="order"
-        ).first()
-        if object_type_mapping and last_synced_at:
-            if last_synced_at >= object_type_mapping.updated_at:
+        active_types = ObjectTypeMapping.objects.filter(
+            event=order.event, eventyay_object_type__in=["order", "order_position"]
+        )
+        if active_types.exists() and last_synced_at:
+            for otm in active_types:
+                if last_synced_at < otm.updated_at:
+                    has_mapping_changes = True
+                    break
+
+            if not has_mapping_changes:
                 sync_needed = False
-            else:
-                has_mapping_changes = True
 
     template = get_template("hubspot/control_order_info.html")
     ctx = {
@@ -218,6 +244,7 @@ def control_order_info(sender, request, order, **kwargs):
         "request": request,
         "event": sender,
         "is_connected": is_connected,
+        "is_paid": order.status == Order.STATUS_PAID,
         "status_text": status_text,
         "status_class": status_class,
         "last_synced_at": last_synced_at,

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -74,7 +74,8 @@ def _enqueue_hubspot_sync(sender, order, **kwargs):
                             direction=SyncDirection.PUSH,
                             status=SyncStatus.PENDING,
                             detail={
-                                "message": f"Auto-sync disabled, sync pending for order {order.code}"
+                                "message": f"Auto-sync disabled, sync pending for order {order.code}",
+                                "order_code": order.code,
                             },
                         )
 
@@ -208,17 +209,11 @@ def control_order_info(sender, request, order, **kwargs):
                 status_text = _("Waiting to sync")
                 status_class = "label label-warning"
     else:
-        pending_logs = SyncLog.objects.filter(
+        pending_log = SyncLog.objects.filter(
             event=order.event,
             status=SyncStatus.PENDING,
-        ).order_by("-created_at")
-
-        pending_log = None
-        for log in pending_logs:
-            if log.detail and isinstance(log.detail, dict):
-                if order.code in log.detail.get("message", ""):
-                    pending_log = log
-                    break
+            detail__order_code=order.code,
+        ).first()
 
         if pending_log:
             status_text = _("Waiting to sync")

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -161,7 +161,7 @@ def control_order_info(sender, request, order, **kwargs):
     if settings and settings.sync_enabled and has_token:
         is_connected = True
 
-    status_text = "Not synced yet"
+    status_text = _("Not synced yet")
     status_class = "label label-default"
     last_synced_at = None
     sync_needed = True
@@ -199,13 +199,13 @@ def control_order_info(sender, request, order, **kwargs):
 
         if latest_log:
             if latest_log.status == SyncStatus.SUCCESS:
-                status_text = "Synced"
+                status_text = _("Synced")
                 status_class = "label label-success"
             elif latest_log.status == SyncStatus.FAILED:
-                status_text = "Failed — could not reach HubSpot"
+                status_text = _("Failed — could not reach HubSpot")
                 status_class = "label label-danger"
             elif latest_log.status == SyncStatus.PENDING:
-                status_text = "Waiting to sync"
+                status_text = _("Waiting to sync")
                 status_class = "label label-warning"
     else:
         pending_logs = SyncLog.objects.filter(
@@ -221,11 +221,11 @@ def control_order_info(sender, request, order, **kwargs):
                     break
 
         if pending_log:
-            status_text = "Waiting to sync"
+            status_text = _("Waiting to sync")
             status_class = "label label-warning"
 
     has_mapping_changes = False
-    if status_text == "Synced":
+    if status_text == _("Synced"):
         active_types = ObjectTypeMapping.objects.filter(
             event=order.event, eventyay_object_type__in=["order", "order_position"]
         )
@@ -236,7 +236,22 @@ def control_order_info(sender, request, order, **kwargs):
                     break
 
             if not has_mapping_changes:
+                active_fields = HubSpotFieldMapping.objects.filter(
+                    event=order.event,
+                    content_type__in=[content_type_order, content_type_position],
+                    is_active=True,
+                )
+                for fm in active_fields:
+                    if last_synced_at < fm.updated_at:
+                        has_mapping_changes = True
+                        break
+
+            if not has_mapping_changes:
                 sync_needed = False
+
+    can_sync = request.user.has_event_permission(
+        request.organizer, request.event, "can_change_event_settings", request
+    )
 
     template = get_template("hubspot/control_order_info.html")
     ctx = {
@@ -250,5 +265,6 @@ def control_order_info(sender, request, order, **kwargs):
         "last_synced_at": last_synced_at,
         "sync_needed": sync_needed,
         "has_mapping_changes": has_mapping_changes,
+        "can_sync": can_sync,
     }
     return template.render(ctx, request=request)

--- a/hubspot/signals.py
+++ b/hubspot/signals.py
@@ -1,5 +1,6 @@
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from django.template.loader import get_template
 from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
@@ -8,6 +9,7 @@ from eventyay.base.models import Order, OrderPosition
 from eventyay.base.signals import periodic_task
 from django.db import transaction
 from eventyay.control.signals import nav_event
+from eventyay.control.signals import order_info
 from django_scopes import scope
 from eventyay.base.signals import order_placed, order_paid, order_canceled
 from .tasks import sync_order_to_hubspot
@@ -144,3 +146,82 @@ def clear_audit_logs(sender, **kwargs):
     threshold = now() - timedelta(days=days)
     AuditLog.objects.filter(created_at__lt=threshold).delete()
     SyncLog.objects.filter(created_at__lt=threshold).delete()
+
+
+@receiver(order_info, dispatch_uid="hubspot_control_order_info")
+def control_order_info(sender, request, order, **kwargs):
+    if not request.user.has_event_permission(
+        request.organizer, request.event, "can_view_orders", request
+    ):
+        return ""
+
+    is_connected = False
+    has_token = HubSpotOAuthToken.objects.filter(event=order.event).exists()
+    settings = HubSpotEventSettings.objects.filter(event=order.event).first()
+    if settings and settings.sync_enabled and has_token:
+        is_connected = True
+
+    status_text = "Not synced yet"
+    status_class = "label label-default"
+    last_synced_at = None
+    sync_needed = True
+
+    content_type = ContentType.objects.get_for_model(Order)
+    mapping = HubSpotObjectMapping.objects.filter(
+        event=order.event, content_type=content_type, object_id=order.id
+    ).first()
+
+    if mapping:
+        last_synced_at = mapping.last_synced_at
+        latest_log = mapping.synclog_set.order_by("-created_at").first()
+        if latest_log:
+            if latest_log.status == SyncStatus.SUCCESS:
+                status_text = "Synced"
+                status_class = "label label-success"
+            elif latest_log.status == SyncStatus.FAILED:
+                status_text = "Failed — could not reach HubSpot"
+                status_class = "label label-danger"
+            elif latest_log.status == SyncStatus.PENDING:
+                status_text = "Waiting to sync"
+                status_class = "label label-warning"
+    else:
+        pending_logs = SyncLog.objects.filter(
+            event=order.event,
+            status=SyncStatus.PENDING,
+        ).order_by("-created_at")
+
+        pending_log = None
+        for log in pending_logs:
+            if log.detail and isinstance(log.detail, dict):
+                if order.code in log.detail.get("message", ""):
+                    pending_log = log
+                    break
+
+        if pending_log:
+            status_text = "Waiting to sync"
+            status_class = "label label-warning"
+
+    has_mapping_changes = False
+    if status_text == "Synced":
+        object_type_mapping = ObjectTypeMapping.objects.filter(
+            event=order.event, eventyay_object_type="order"
+        ).first()
+        if object_type_mapping and last_synced_at:
+            if last_synced_at >= object_type_mapping.updated_at:
+                sync_needed = False
+            else:
+                has_mapping_changes = True
+
+    template = get_template("hubspot/control_order_info.html")
+    ctx = {
+        "order": order,
+        "request": request,
+        "event": sender,
+        "is_connected": is_connected,
+        "status_text": status_text,
+        "status_class": status_class,
+        "last_synced_at": last_synced_at,
+        "sync_needed": sync_needed,
+        "has_mapping_changes": has_mapping_changes,
+    }
+    return template.render(ctx, request=request)

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -329,7 +329,7 @@ def sync_order_to_hubspot(self, order_id: int, event_id: int):
             SyncLog.objects.filter(
                 event=event,
                 status=SyncStatus.PENDING,
-                detail__message__contains=order.code,
+                detail__order_code=order.code,
             ).delete()
             return
 
@@ -348,7 +348,7 @@ def sync_order_to_hubspot(self, order_id: int, event_id: int):
             SyncLog.objects.filter(
                 event=event,
                 status=SyncStatus.PENDING,
-                detail__message__contains=order.code,
+                detail__order_code=order.code,
             ).delete()
         except HubSpotTransientError as e:
             delay = 2**self.request.retries

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -325,6 +325,12 @@ def sync_order_to_hubspot(self, order_id: int, event_id: int):
             logger.info(
                 f"No active object mappings found for event {event_id}. Skipping sync for order {order_id}."
             )
+            # Clean up pending logs for this order
+            SyncLog.objects.filter(
+                event=event,
+                status=SyncStatus.PENDING,
+                detail__message__contains=order.code,
+            ).delete()
             return
 
         try:
@@ -337,6 +343,13 @@ def sync_order_to_hubspot(self, order_id: int, event_id: int):
 
                 for obj in objects_to_sync:
                     _sync_single_object(event, object_mapping_config, obj)
+
+            # Clean up pending logs for this order
+            SyncLog.objects.filter(
+                event=event,
+                status=SyncStatus.PENDING,
+                detail__message__contains=order.code,
+            ).delete()
         except HubSpotTransientError as e:
             delay = 2**self.request.retries
             retry_after = getattr(e, "retry_after_seconds", None)

--- a/hubspot/templates/hubspot/control_order_info.html
+++ b/hubspot/templates/hubspot/control_order_info.html
@@ -26,7 +26,11 @@
             <form action="{% url "plugins:hubspot:sync_order" organizer=event.organizer.slug event=event.slug order=order.code %}" method="post" style="margin: 0;">
                 {% csrf_token %}
                 {% if is_connected %}
-                    {% if sync_needed %}
+                    {% if not is_paid %}
+                    <button type="button" class="btn btn-primary sync-now-btn" disabled data-toggle="tooltip" title="{% trans "Order must be paid to sync." %}">
+                        {% trans "Sync now" %}
+                    </button>
+                    {% elif sync_needed %}
                     <button type="submit" class="btn btn-primary sync-now-btn" onclick="this.innerHTML='{% trans "Queued" %}'; this.disabled=true; this.form.submit();">
                         {% trans "Sync now" %}
                     </button>

--- a/hubspot/templates/hubspot/control_order_info.html
+++ b/hubspot/templates/hubspot/control_order_info.html
@@ -35,7 +35,7 @@
                         {% trans "Sync now" %}
                     </button>
                     {% elif sync_needed %}
-                    <button type="submit" class="btn btn-primary sync-now-btn" onclick="this.innerHTML='{% trans "Queued" %}'; this.disabled=true; this.form.submit();">
+                    <button type="button" class="btn btn-primary sync-now-btn" onclick="this.innerHTML='{% trans "Queued" %}'; this.disabled=true; this.form.submit();">
                         {% trans "Sync now" %}
                     </button>
                     {% else %}

--- a/hubspot/templates/hubspot/control_order_info.html
+++ b/hubspot/templates/hubspot/control_order_info.html
@@ -25,7 +25,11 @@
             
             <form action="{% url "plugins:hubspot:sync_order" organizer=event.organizer.slug event=event.slug order=order.code %}" method="post" style="margin: 0;">
                 {% csrf_token %}
-                {% if is_connected %}
+                {% if not can_sync %}
+                    <button type="button" class="btn btn-primary sync-now-btn" disabled data-toggle="tooltip" title="{% trans "You do not have permission to sync orders." %}">
+                        {% trans "Sync now" %}
+                    </button>
+                {% elif is_connected %}
                     {% if not is_paid %}
                     <button type="button" class="btn btn-primary sync-now-btn" disabled data-toggle="tooltip" title="{% trans "Order must be paid to sync." %}">
                         {% trans "Sync now" %}

--- a/hubspot/templates/hubspot/control_order_info.html
+++ b/hubspot/templates/hubspot/control_order_info.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">
+            {% trans "HubSpot Sync Status" %}
+        </h3>
+    </div>
+    <div class="panel-body">
+        {% if has_mapping_changes %}
+        <div class="alert alert-info">
+            {% trans "The HubSpot mapping configuration has been updated since this order was last synced. You may want to sync again." %}
+        </div>
+        {% endif %}
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <div>
+                <span style="margin-right: 20px;">
+                    <strong>{% trans "Status:" %}</strong> <span class="{{ status_class }}">{{ status_text }}</span>
+                </span>
+                {% if last_synced_at %}
+                <span>
+                    <strong>{% trans "Last synced at:" %}</strong> {{ last_synced_at|date:"Y-m-d H:i:s" }}
+                </span>
+                {% endif %}
+            </div>
+            
+            <form action="{% url "plugins:hubspot:sync_order" organizer=event.organizer.slug event=event.slug order=order.code %}" method="post" style="margin: 0;">
+                {% csrf_token %}
+                {% if is_connected %}
+                    {% if sync_needed %}
+                    <button type="submit" class="btn btn-primary sync-now-btn" onclick="this.innerHTML='{% trans "Queued" %}'; this.disabled=true; this.form.submit();">
+                        {% trans "Sync now" %}
+                    </button>
+                    {% else %}
+                    <button type="button" class="btn btn-primary sync-now-btn" disabled data-toggle="tooltip" title="{% trans "Order is already synced and no mapping changes detected." %}">
+                        {% trans "Sync now" %}
+                    </button>
+                    {% endif %}
+                {% else %}
+                    <button type="button" class="btn btn-primary" disabled data-toggle="tooltip" title="{% trans "HubSpot is not connected for this event." %}">
+                        {% trans "Sync now" %}
+                    </button>
+                {% endif %}
+            </form>
+        </div>
+    </div>
+</div>

--- a/hubspot/urls.py
+++ b/hubspot/urls.py
@@ -12,6 +12,7 @@ from hubspot.views import (
     RetryAllFailedView,
     SyncRetryBulkView,
     DismissSyncView,
+    SyncOrderNowView,
 )
 
 urlpatterns = [
@@ -74,5 +75,10 @@ urlpatterns = [
         "control/event/<orgslug:organizer>/<slug:event>/hubspot/sync-problems/dismiss/<int:log_id>/",
         DismissSyncView.as_view(),
         name="sync_dismiss",
+    ),
+    path(
+        "control/event/<orgslug:organizer>/<slug:event>/hubspot/sync-order/<str:order>/",
+        SyncOrderNowView.as_view(),
+        name="sync_order",
     ),
 ]

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -956,6 +956,19 @@ class SyncOrderNowView(EventPermissionRequiredMixin, View):
         try:
             order = Order.objects.get(code=order_code, event=request.event)
 
+            if order.status != Order.STATUS_PAID:
+                messages.error(request, _("Only paid orders can be synced."))
+                return redirect(
+                    reverse(
+                        "control:event.order",
+                        kwargs={
+                            "organizer": request.event.organizer.slug,
+                            "event": request.event.slug,
+                            "code": order_code,
+                        },
+                    )
+                )
+
             # Create a pending SyncLog so the UI updates immediately
             from .models import HubSpotObjectMapping
 

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -955,6 +955,24 @@ class SyncOrderNowView(EventPermissionRequiredMixin, View):
         order_code = kwargs["order"]
         try:
             order = Order.objects.get(code=order_code, event=request.event)
+
+            # Create a pending SyncLog so the UI updates immediately
+            from .models import HubSpotObjectMapping
+
+            content_type = ContentType.objects.get_for_model(Order)
+            mapping = HubSpotObjectMapping.objects.filter(
+                event=request.event, content_type=content_type, object_id=order.id
+            ).first()
+
+            SyncLog.objects.create(
+                event=request.event,
+                object_mapping=mapping,
+                action=SyncAction.UPDATE,
+                direction=SyncDirection.PUSH,
+                status=SyncStatus.PENDING,
+                detail={"message": f"Manual sync requested for order {order.code}"},
+            )
+
             sync_order_to_hubspot.apply_async(args=[order.id, request.event.id])
             messages.success(request, _("Sync task queued."))
         except Order.DoesNotExist:

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -983,7 +983,10 @@ class SyncOrderNowView(EventPermissionRequiredMixin, View):
                 action=SyncAction.UPDATE,
                 direction=SyncDirection.PUSH,
                 status=SyncStatus.PENDING,
-                detail={"message": f"Manual sync requested for order {order.code}"},
+                detail={
+                    "message": f"Manual sync requested for order {order.code}",
+                    "order_code": order.code,
+                },
             )
 
             sync_order_to_hubspot.apply_async(args=[order.id, request.event.id])

--- a/hubspot/views.py
+++ b/hubspot/views.py
@@ -944,3 +944,29 @@ class DismissSyncView(EventPermissionRequiredMixin, View):
                 },
             )
         )
+
+
+class SyncOrderNowView(EventPermissionRequiredMixin, View):
+    """Re-queues a single order for sync directly from the order detail page."""
+
+    permission = "can_change_event_settings"
+
+    def post(self, request, *args, **kwargs):
+        order_code = kwargs["order"]
+        try:
+            order = Order.objects.get(code=order_code, event=request.event)
+            sync_order_to_hubspot.apply_async(args=[order.id, request.event.id])
+            messages.success(request, _("Sync task queued."))
+        except Order.DoesNotExist:
+            messages.error(request, _("Order not found."))
+
+        return redirect(
+            reverse(
+                "control:event.order",
+                kwargs={
+                    "organizer": request.event.organizer.slug,
+                    "event": request.event.slug,
+                    "code": order_code,
+                },
+            )
+        )

--- a/tests/test_order_detail.py
+++ b/tests/test_order_detail.py
@@ -1,0 +1,191 @@
+import datetime
+from django.utils.timezone import now
+import pytest
+from unittest import mock
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from django_scopes import scopes_disabled
+
+from eventyay.base.models import Order
+from hubspot.models import (
+    HubSpotEventSettings,
+    HubSpotOAuthToken,
+    HubSpotObjectMapping,
+    SyncLog,
+    SyncStatus,
+    SyncAction,
+    SyncDirection,
+)
+from hubspot.signals import control_order_info
+
+
+@pytest.fixture(autouse=True)
+def disable_scopes():
+    with scopes_disabled():
+        yield
+
+
+@pytest.mark.django_db
+def test_order_info_not_connected(client, event, order, organizer):
+    class DummyRequest:
+        def __init__(self):
+            self.user = mock.Mock()
+            self.user.has_event_permission.return_value = True
+            self.event = event
+            self.organizer = organizer
+            self.META = {}
+            self.resolver_match = mock.Mock()
+            self.resolver_match.namespaces = []
+            self.path = ""
+            self.path_info = ""
+
+    req = DummyRequest()
+    html = control_order_info(event, req, order)
+
+    assert "HubSpot is not connected for this event." in html
+    assert "Not synced yet" in html
+    assert "disabled" in html
+
+
+@pytest.mark.django_db
+def test_order_info_synced(client, event, order, organizer):
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
+    HubSpotOAuthToken.objects.create(
+        event=event,
+        access_token="acc",
+        refresh_token="ref",
+        expires_at=now() + datetime.timedelta(days=1),
+    )
+    mapping = HubSpotObjectMapping.objects.create(
+        event=event,
+        content_type=ContentType.objects.get_for_model(Order),
+        object_id=order.id,
+        hubspot_object_type="contacts",
+        hubspot_object_id="123",
+        last_synced_at=now(),
+    )
+    SyncLog.objects.create(
+        event=event,
+        object_mapping=mapping,
+        action=SyncAction.CREATE,
+        direction=SyncDirection.PUSH,
+        status=SyncStatus.SUCCESS,
+    )
+
+    class DummyRequest:
+        def __init__(self):
+            self.user = mock.Mock()
+            self.user.has_event_permission.return_value = True
+            self.event = event
+            self.organizer = organizer
+            self.META = {}
+            self.resolver_match = mock.Mock()
+            self.resolver_match.namespaces = []
+            self.path = ""
+            self.path_info = ""
+
+    req = DummyRequest()
+    html = control_order_info(event, req, order)
+
+    assert "Synced" in html
+    assert "HubSpot is not connected" not in html
+    assert 'class="btn btn-primary sync-now-btn"' in html
+
+
+@pytest.mark.django_db
+def test_order_info_failed(client, event, order, organizer):
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
+    HubSpotOAuthToken.objects.create(
+        event=event,
+        access_token="acc",
+        refresh_token="ref",
+        expires_at=now() + datetime.timedelta(days=1),
+    )
+    mapping = HubSpotObjectMapping.objects.create(
+        event=event,
+        content_type=ContentType.objects.get_for_model(Order),
+        object_id=order.id,
+        hubspot_object_type="contacts",
+        hubspot_object_id="123",
+    )
+    SyncLog.objects.create(
+        event=event,
+        object_mapping=mapping,
+        action=SyncAction.CREATE,
+        direction=SyncDirection.PUSH,
+        status=SyncStatus.FAILED,
+    )
+
+    class DummyRequest:
+        def __init__(self):
+            self.user = mock.Mock()
+            self.user.has_event_permission.return_value = True
+            self.event = event
+            self.organizer = organizer
+            self.META = {}
+            self.resolver_match = mock.Mock()
+            self.resolver_match.namespaces = []
+            self.path = ""
+            self.path_info = ""
+
+    req = DummyRequest()
+    html = control_order_info(event, req, order)
+
+    assert "Failed" in html
+
+
+@pytest.mark.django_db
+def test_order_info_pending_no_mapping(client, event, order, organizer):
+    HubSpotEventSettings.objects.create(event=event, sync_enabled=True)
+    HubSpotOAuthToken.objects.create(
+        event=event,
+        access_token="acc",
+        refresh_token="ref",
+        expires_at=now() + datetime.timedelta(days=1),
+    )
+    SyncLog.objects.create(
+        event=event,
+        action=SyncAction.CREATE,
+        direction=SyncDirection.PUSH,
+        status=SyncStatus.PENDING,
+        detail={"message": f"Auto-sync disabled, sync pending for order {order.code}"},
+    )
+
+    class DummyRequest:
+        def __init__(self):
+            self.user = mock.Mock()
+            self.user.has_event_permission.return_value = True
+            self.event = event
+            self.organizer = organizer
+            self.META = {}
+            self.resolver_match = mock.Mock()
+            self.resolver_match.namespaces = []
+            self.path = ""
+            self.path_info = ""
+
+    req = DummyRequest()
+    html = control_order_info(event, req, order)
+
+    assert "Waiting to sync" in html
+
+
+@pytest.mark.django_db
+@mock.patch("hubspot.views.sync_order_to_hubspot.apply_async")
+def test_sync_now_view(
+    mock_apply, logged_in_organizer_client, event, order, organizer, settings
+):
+    settings.SITE_URL = "https://testserver"
+
+    url = reverse(
+        "plugins:hubspot:sync_order",
+        kwargs={"organizer": organizer.slug, "event": event.slug, "order": order.code},
+    )
+
+    response = logged_in_organizer_client.post(url)
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "control:event.order",
+        kwargs={"organizer": organizer.slug, "event": event.slug, "code": order.code},
+    )
+
+    mock_apply.assert_called_once_with(args=[order.id, event.id])

--- a/tests/test_order_detail.py
+++ b/tests/test_order_detail.py
@@ -148,7 +148,10 @@ def test_order_info_pending_no_mapping(client, event, order, organizer):
         action=SyncAction.CREATE,
         direction=SyncDirection.PUSH,
         status=SyncStatus.PENDING,
-        detail={"message": f"Auto-sync disabled, sync pending for order {order.code}"},
+        detail={
+            "message": f"Auto-sync disabled, sync pending for order {order.code}",
+            "order_code": order.code,
+        },
     )
 
     class DummyRequest:
@@ -175,6 +178,9 @@ def test_sync_now_view(
     mock_apply, logged_in_organizer_client, event, order, organizer, settings
 ):
     settings.SITE_URL = "https://testserver"
+
+    order.status = Order.STATUS_PAID
+    order.save()
 
     url = reverse(
         "plugins:hubspot:sync_order",


### PR DESCRIPTION
## Closes #37 

> [!NOTE]
> - This is a stacked PR and will be ready to review after #40 gets merged
> 
> | [View Diff for this branch](https://github.com/ViRUS-0-0/eventyay-hubspot/compare/ViRUS-0-0:sync-page...ViRUS-0-0:per-order-sync) |
> | :--- |

## Tasks Covered
- [x] Add a "HubSpot" section to the order detail page in the plugin's order detail signal/hook
- [x] The section shows: current sync status in plain language (e.g. "Synced", "Waiting to sync", "Failed — could not reach HubSpot"), and when it last synced successfully
- [x] Add a "Sync now" button that queues the sync task for that order immediately, regardless of whether auto-sync is on or off
- [x] The "Sync now" button is disabled with a tooltip if HubSpot is not connected for that event
- [x] If the order has never been synced and there is no sync record, show "Not synced yet" with a "Sync now" button
- [x] After clicking "Sync now", the button changes to "Queued" temporarily so the organiser knows something happened
- [x] Write tests checking: correct status shown for each state (pending, synced, failed, never synced), button disabled when not connected, clicking sync queues the task

## Videos\Screenshot

https://github.com/user-attachments/assets/390b373d-54b4-4bc1-bc4d-f506c46c7f72

---

https://github.com/user-attachments/assets/3b16ed9e-30a2-49c7-a207-4e26343fe4ac

---

<img width="957" height="353" alt="Screenshot 2026-07-14 at 12 39 51 PM" src="https://github.com/user-attachments/assets/fbf5b5b9-74c3-492b-a6e7-017a417c80a9" />

---

<img width="970" height="342" alt="Screenshot 2026-07-14 at 12 40 01 PM" src="https://github.com/user-attachments/assets/42d8f9fc-b2ad-428e-a8f7-e1120e41061a" />

---

<img width="1213" height="672" alt="Screenshot 2026-07-14 at 12 39 34 PM" src="https://github.com/user-attachments/assets/8d4ebef9-2181-4358-a6c4-2a2e12b4c1e2" />

---

<img width="975" height="149" alt="Screenshot 2026-07-17 at 1 14 24 AM" src="https://github.com/user-attachments/assets/322f5702-b772-4e9d-b1dc-ed2707c663bd" />
